### PR TITLE
Add Team dashboard page with date-filtered charts and roster

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import tieIcon from '../../resources/tie.png'
 
 const ReportDetail = lazy(() => import('./pages/ReportDetail').then(m => ({ default: m.ReportDetail })))
 const Playbook = lazy(() => import('./pages/Playbook').then(m => ({ default: m.Playbook })))
+const TeamPage = lazy(() => import('./pages/Team').then(m => ({ default: m.Team })))
 
 const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.Settings })))
 const ContextDetail = lazy(() => import('./pages/ContextDetail').then(m => ({ default: m.ContextDetail })))
@@ -95,6 +96,7 @@ export default function App() {
       element: <Layout />,
       children: [
         { path: '/', element: <Today /> },
+        { path: '/team', element: <TeamPage /> },
         { path: '/playbook', element: <Playbook /> },
         { path: '/chat', element: <Chat /> },
         { path: '/report/:name', element: <ReportDetail /> },

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -31,8 +31,8 @@ interface AppShellProps {
 
 const navItems = [
   { path: '/', icon: Sun, label: 'Today', shortcut: 'cmd+1' },
-  { path: '/team', icon: Users, label: 'Team', shortcut: 'cmd+2' },
-  { path: '/playbook', icon: BookOpen, label: 'Playbook', shortcut: 'cmd+3' },
+  { path: '/playbook', icon: BookOpen, label: 'Playbook', shortcut: 'cmd+2' },
+  { path: '/team', icon: Users, label: 'Team', shortcut: 'cmd+3' },
   { path: '/chat', icon: MessageSquare, label: 'Chat', shortcut: 'cmd+4' },
   { path: '/search', icon: Search, label: 'Search', shortcut: 'cmd+5' }
 ]

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -11,7 +11,8 @@ import {
   ClipboardPaste,
   Keyboard,
   Plus,
-  RefreshCw
+  RefreshCw,
+  Users
 } from 'lucide-react'
 import { useTeamOverview, useSettings } from '../../hooks/useData'
 import { useAuth } from '../../hooks/useAuth'
@@ -30,9 +31,10 @@ interface AppShellProps {
 
 const navItems = [
   { path: '/', icon: Sun, label: 'Today', shortcut: 'cmd+1' },
-  { path: '/playbook', icon: BookOpen, label: 'Playbook', shortcut: 'cmd+2' },
-  { path: '/chat', icon: MessageSquare, label: 'Chat', shortcut: 'cmd+3' },
-  { path: '/search', icon: Search, label: 'Search', shortcut: 'cmd+4' }
+  { path: '/team', icon: Users, label: 'Team', shortcut: 'cmd+2' },
+  { path: '/playbook', icon: BookOpen, label: 'Playbook', shortcut: 'cmd+3' },
+  { path: '/chat', icon: MessageSquare, label: 'Chat', shortcut: 'cmd+4' },
+  { path: '/search', icon: Search, label: 'Search', shortcut: 'cmd+5' }
 ]
 
 export function AppShell({ children }: AppShellProps) {
@@ -168,7 +170,7 @@ export function AppShell({ children }: AppShellProps) {
         e.preventDefault()
         setShortcutsOpen(prev => !prev)
       }
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '4') {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '5') {
         const idx = parseInt(e.key) - 1
         if (navItems[idx]) {
           e.preventDefault()

--- a/src/renderer/pages/Team.tsx
+++ b/src/renderer/pages/Team.tsx
@@ -1,0 +1,611 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTeamOverview } from '../hooks/useData'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useToast } from '../components/common/Toast'
+import { format, subDays, subWeeks, startOfWeek, parseISO } from 'date-fns'
+import {
+  Users,
+  Calendar,
+  RefreshCw,
+  Loader2,
+  MapPin,
+  Briefcase,
+  MessageSquare,
+  CheckSquare,
+  GitPullRequest,
+  AlertCircle
+} from 'lucide-react'
+import { GitHubMark } from '../components/common/GitHubMark'
+import type { PersonActivityResult, FeedbackEntry, ReportStatus, Report } from '../../shared/types'
+
+// ── Types ──
+
+interface TeamMemberDashboard {
+  report: ReportStatus
+  activity: PersonActivityResult | null
+  feedback: FeedbackEntry[]
+}
+
+type DatePreset = '1w' | '2w' | '1m' | '3m' | 'custom'
+
+// ── Chart color palette ──
+const COLORS = [
+  '#60a5fa', '#f472b6', '#34d399', '#fbbf24', '#a78bfa',
+  '#fb923c', '#2dd4bf', '#e879f9', '#94a3b8', '#f87171',
+]
+
+// ── Helpers ──
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  d.setDate(diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+interface WeekBucket {
+  weekStart: string
+  label: string
+  byPerson: Record<string, { authored: number; reviewed: number }>
+}
+
+function aggregateActivityByWeek(
+  members: TeamMemberDashboard[],
+  startDate: string,
+  endDate: string
+): { buckets: WeekBucket[]; people: string[] } {
+  const start = getWeekStart(new Date(startDate))
+  const end = new Date(endDate)
+
+  const buckets: WeekBucket[] = []
+  const cursor = new Date(start)
+  while (cursor <= end) {
+    buckets.push({
+      weekStart: cursor.toISOString().split('T')[0],
+      label: format(cursor, 'MMM d'),
+      byPerson: {}
+    })
+    cursor.setDate(cursor.getDate() + 7)
+  }
+
+  const people = new Set<string>()
+
+  for (const member of members) {
+    if (!member.activity?.items.length) continue
+    const name = member.report.displayName
+    const hasPRs = member.activity.items.some(i => i.type === 'pr')
+    if (hasPRs) people.add(name)
+
+    for (const item of member.activity.items) {
+      if (item.type !== 'pr') continue
+      const itemWeekStart = getWeekStart(new Date(item.createdAt))
+      const itemWeekStr = itemWeekStart.toISOString().split('T')[0]
+      const bucket = buckets.find(b => b.weekStart === itemWeekStr)
+      if (!bucket) continue
+      if (!bucket.byPerson[name]) bucket.byPerson[name] = { authored: 0, reviewed: 0 }
+      if (item.role === 'author') bucket.byPerson[name].authored++
+      else bucket.byPerson[name].reviewed++
+    }
+  }
+
+  return { buckets, people: Array.from(people).sort() }
+}
+
+// ── SVG Chart with hover tooltips ──
+
+function ActivityChart({ members, startDate, endDate }: {
+  members: TeamMemberDashboard[]
+  startDate: string
+  endDate: string
+}) {
+  const { buckets, people } = useMemo(
+    () => aggregateActivityByWeek(members, startDate, endDate),
+    [members, startDate, endDate]
+  )
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null)
+
+  if (people.length === 0) {
+    return <div className="py-8 text-center text-sm text-zinc-500">No PR activity in this period</div>
+  }
+
+  const width = 700
+  const height = 200
+  const pL = 36, pR = 16, pT = 16, pB = 36
+  const cW = width - pL - pR
+  const cH = height - pT - pB
+  const xStep = cW / Math.max(buckets.length - 1, 1)
+
+  // Per-person line data (not stacked — individual lines are easier to read)
+  const maxVal = Math.max(1, ...buckets.map(b =>
+    Math.max(...people.map(p => {
+      const d = b.byPerson[p]
+      return d ? d.authored + d.reviewed : 0
+    }))
+  ))
+
+  const yTicks: number[] = []
+  const step = maxVal <= 5 ? 1 : maxVal <= 20 ? 5 : 10
+  for (let v = 0; v <= maxVal; v += step) yTicks.push(v)
+
+  return (
+    <div className="relative">
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
+        {/* Grid */}
+        {yTicks.map(v => {
+          const y = pT + cH - (v / maxVal) * cH
+          return (
+            <g key={v}>
+              <line x1={pL} y1={y} x2={width - pR} y2={y} stroke="rgba(255,255,255,0.04)" />
+              <text x={pL - 8} y={y + 3} textAnchor="end" className="fill-zinc-600" fontSize={9}>{v}</text>
+            </g>
+          )
+        })}
+
+        {/* X labels */}
+        {buckets.map((b, i) => (
+          <text key={b.weekStart} x={pL + i * xStep} y={height - 8} textAnchor="middle" className="fill-zinc-600" fontSize={9}>
+            {b.label}
+          </text>
+        ))}
+
+        {/* Lines per person */}
+        {people.map((person, pi) => {
+          const color = COLORS[pi % COLORS.length]
+          const points = buckets.map((b, i) => {
+            const d = b.byPerson[person]
+            const val = d ? d.authored + d.reviewed : 0
+            return { x: pL + i * xStep, y: pT + cH - (val / maxVal) * cH, val }
+          })
+          const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
+
+          return (
+            <g key={person}>
+              <path d={linePath} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeOpacity={0.8} />
+              {points.map((p, i) => (
+                <circle
+                  key={i}
+                  cx={p.x} cy={p.y} r={p.val > 0 ? 3.5 : 0}
+                  fill={color} fillOpacity={0.9}
+                  className="cursor-pointer"
+                  onMouseEnter={(e) => {
+                    const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
+                    if (!rect) return
+                    const authored = buckets[i].byPerson[person]?.authored ?? 0
+                    const reviewed = buckets[i].byPerson[person]?.reviewed ?? 0
+                    setTooltip({
+                      x: e.clientX - rect.left,
+                      y: e.clientY - rect.top - 40,
+                      content: `${person.split(' ')[0]}: ${authored} authored, ${reviewed} reviewed (${buckets[i].label})`
+                    })
+                  }}
+                  onMouseLeave={() => setTooltip(null)}
+                />
+              ))}
+            </g>
+          )
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
+          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}
+        >
+          {tooltip.content}
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 px-1">
+        {people.map((person, pi) => (
+          <div key={person} className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: COLORS[pi % COLORS.length] }} />
+            <span className="text-[11px] text-zinc-400">{person.split(' ')[0]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Feedback balance chart ──
+
+function FeedbackChart({ members }: { members: TeamMemberDashboard[] }) {
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null)
+
+  const data = useMemo(() => {
+    return members
+      .map(m => {
+        const positive = m.feedback.filter(f => f.type === 'positive').length
+        const constructive = m.feedback.filter(f => f.type === 'constructive').length
+        const other = m.feedback.filter(f => f.type !== 'positive' && f.type !== 'constructive').length
+        return { name: m.report.displayName, positive, constructive, other, total: positive + constructive + other }
+      })
+      .sort((a, b) => b.total - a.total)
+  }, [members])
+
+  const maxTotal = Math.max(1, ...data.map(d => d.total))
+
+  if (data.every(d => d.total === 0)) {
+    return <div className="py-8 text-center text-sm text-zinc-500">No feedback in this period</div>
+  }
+
+  const barHeight = 28
+  const gap = 6
+  const labelWidth = 80
+  const chartWidth = 400
+  const totalHeight = data.length * (barHeight + gap)
+
+  return (
+    <div className="relative">
+      <svg viewBox={`0 0 ${labelWidth + chartWidth + 40} ${totalHeight}`} className="w-full">
+        {data.map((d, i) => {
+          const y = i * (barHeight + gap)
+          const posW = (d.positive / maxTotal) * chartWidth
+          const conW = (d.constructive / maxTotal) * chartWidth
+          const othW = (d.other / maxTotal) * chartWidth
+
+          return (
+            <g key={d.name}>
+              <text x={labelWidth - 8} y={y + barHeight / 2 + 4} textAnchor="end" className="fill-zinc-400" fontSize={11}>
+                {d.name.split(' ')[0]}
+              </text>
+              {/* Positive */}
+              <rect
+                x={labelWidth} y={y + 2} width={Math.max(posW, 0)} height={barHeight - 4}
+                rx={4} fill="#34d399" fillOpacity={0.7}
+                className="cursor-pointer"
+                onMouseEnter={(e) => {
+                  const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
+                  if (!rect) return
+                  setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${d.name}: ${d.positive} positive` })
+                }}
+                onMouseLeave={() => setTooltip(null)}
+              />
+              {/* Constructive */}
+              <rect
+                x={labelWidth + posW} y={y + 2} width={Math.max(conW, 0)} height={barHeight - 4}
+                rx={conW > 0 && posW === 0 ? 4 : 0} fill="#f59e0b" fillOpacity={0.7}
+                className="cursor-pointer"
+                onMouseEnter={(e) => {
+                  const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
+                  if (!rect) return
+                  setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${d.name}: ${d.constructive} constructive` })
+                }}
+                onMouseLeave={() => setTooltip(null)}
+              />
+              {/* Other */}
+              {othW > 0 && (
+                <rect
+                  x={labelWidth + posW + conW} y={y + 2} width={Math.max(othW, 0)} height={barHeight - 4}
+                  rx={0} fill="#94a3b8" fillOpacity={0.5}
+                />
+              )}
+              {/* Count */}
+              <text x={labelWidth + posW + conW + othW + 6} y={y + barHeight / 2 + 4} className="fill-zinc-600" fontSize={10}>
+                {d.total}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+
+      {tooltip && (
+        <div
+          className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
+          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}
+        >
+          {tooltip.content}
+        </div>
+      )}
+
+      <div className="flex gap-4 mt-2 px-1">
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-emerald-400" />
+          <span className="text-[11px] text-zinc-400">Positive</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-2 h-2 rounded-full bg-amber-400" />
+          <span className="text-[11px] text-zinc-400">Constructive</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Team Roster Grid ──
+
+function RosterCard({ report, activity, feedback, navigate }: {
+  report: ReportStatus
+  activity: PersonActivityResult | null
+  feedback: FeedbackEntry[]
+  navigate: (path: string) => void
+}) {
+  const statusColor = report.status === 'at-risk' ? 'border-rose-500/30' : report.status === 'needs-attention' ? 'border-amber-500/30' : 'border-border/60'
+  const dotColor = report.status === 'at-risk' ? 'bg-rose-400' : report.status === 'needs-attention' ? 'bg-amber-400' : 'bg-emerald-400'
+  const prAuthored = activity?.items.filter(i => i.type === 'pr' && i.role === 'author').length ?? 0
+  const prReviewed = activity?.items.filter(i => i.type === 'pr' && i.role !== 'author').length ?? 0
+
+  return (
+    <button
+      onClick={() => navigate(`/report/${report.name}`)}
+      className={`flex flex-col p-4 bg-surface rounded-xl border ${statusColor} hover:bg-surface-raised/50 transition-all text-left group`}
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <div className="relative shrink-0">
+          {report.github ? (
+            <img src={`https://github.com/${report.github}.png?size=48`} alt="" className="w-10 h-10 rounded-full object-cover" />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center text-sm font-semibold text-zinc-500">
+              {report.displayName.charAt(0)}
+            </div>
+          )}
+          <div className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full ${dotColor} ring-2 ring-surface`} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-zinc-200 truncate">{report.displayName}</p>
+          {report.github && (
+            <p className="text-[11px] text-zinc-500 truncate">@{report.github}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-[11px]">
+        <div className="flex items-center gap-1 text-zinc-500">
+          <Calendar className="w-3 h-3" aria-hidden="true" />
+          {report.lastOneOnOne ? `${report.daysGap}d ago` : 'No 1:1s'}
+        </div>
+        <div className="flex items-center gap-1 text-zinc-500">
+          <CheckSquare className="w-3 h-3" aria-hidden="true" />
+          {report.openActionItems} actions
+        </div>
+        <div className="flex items-center gap-1 text-zinc-500">
+          <GitPullRequest className="w-3 h-3" aria-hidden="true" />
+          {prAuthored}a / {prReviewed}r
+        </div>
+        <div className="flex items-center gap-1 text-zinc-500">
+          <MessageSquare className="w-3 h-3" aria-hidden="true" />
+          {feedback.length} feedback
+        </div>
+      </div>
+    </button>
+  )
+}
+
+// ── Main Team Page ──
+
+export function Team() {
+  useDocumentTitle('Team')
+  const { overview, loading: overviewLoading } = useTeamOverview()
+  const navigate = useNavigate()
+  const toast = useToast()
+
+  const [preset, setPreset] = useState<DatePreset>('1m')
+  const [customStart, setCustomStart] = useState('')
+  const [customEnd, setCustomEnd] = useState('')
+  const [members, setMembers] = useState<TeamMemberDashboard[]>([])
+  const [loadingData, setLoadingData] = useState(false)
+
+  const reports = overview?.reports ?? []
+
+  const { startDate, endDate } = useMemo(() => {
+    if (preset === 'custom' && customStart && customEnd) {
+      return { startDate: customStart, endDate: customEnd }
+    }
+    const now = new Date()
+    const end = format(now, 'yyyy-MM-dd')
+    const daysMap: Record<string, number> = { '1w': 7, '2w': 14, '1m': 30, '3m': 90 }
+    const days = daysMap[preset] ?? 30
+    const start = format(subDays(now, days), 'yyyy-MM-dd')
+    return { startDate: start, endDate: end }
+  }, [preset, customStart, customEnd])
+
+  const fetchDashboardData = useCallback(async () => {
+    if (!reports.length) return
+    setLoadingData(true)
+
+    try {
+      const results = await Promise.all(
+        reports.map(async (report): Promise<TeamMemberDashboard> => {
+          const [activity, reportData] = await Promise.all([
+            window.api.fetchActivityForPerson(report.name, startDate, endDate).catch(() => null),
+            window.api.getReportData(report.name).catch(() => null)
+          ])
+
+          // Filter feedback to date range
+          const allFeedback = reportData?.feedback ?? []
+          const filtered = allFeedback.filter(f => {
+            if (!f.date) return false
+            return f.date >= startDate && f.date <= endDate
+          })
+
+          return { report, activity, feedback: filtered }
+        })
+      )
+      setMembers(results)
+    } catch (e) {
+      console.error('Failed to fetch team dashboard data:', e)
+      toast.error('Failed to load team data')
+    } finally {
+      setLoadingData(false)
+    }
+  }, [reports.length, startDate, endDate, toast])
+
+  useEffect(() => {
+    if (reports.length > 0) fetchDashboardData()
+  }, [reports.length, startDate, endDate]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Summary stats ──
+  const stats = useMemo(() => {
+    let totalPRs = 0, totalReviews = 0, totalFeedback = 0, totalActions = 0
+    for (const m of members) {
+      const items = m.activity?.items ?? []
+      totalPRs += items.filter(i => i.type === 'pr' && i.role === 'author').length
+      totalReviews += items.filter(i => i.type === 'pr' && i.role !== 'author').length
+      totalFeedback += m.feedback.length
+      totalActions += m.report.openActionItems
+    }
+    return { totalPRs, totalReviews, totalFeedback, totalActions }
+  }, [members])
+
+  if (overviewLoading) {
+    return (
+      <div className="max-w-5xl mx-auto space-y-6 animate-fade-in">
+        <div className="skeleton h-8 w-40 rounded" />
+        <div className="skeleton h-4 w-64 rounded" />
+        <div className="grid grid-cols-4 gap-3">
+          {[1, 2, 3, 4].map(i => <div key={i} className="skeleton h-20 rounded-xl" />)}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6 animate-fade-in">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-zinc-50 tracking-tight flex items-center gap-2">
+            <Users className="w-6 h-6 text-brand-light" aria-hidden="true" />
+            Team
+          </h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            {reports.length} report{reports.length !== 1 ? 's' : ''} · {format(parseISO(startDate), 'MMM d')} to {format(parseISO(endDate), 'MMM d, yyyy')}
+          </p>
+        </div>
+        <button
+          onClick={fetchDashboardData}
+          disabled={loadingData}
+          className="p-2 text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.04] rounded-lg transition-colors disabled:opacity-50"
+          aria-label="Refresh"
+        >
+          <RefreshCw className={`w-4 h-4 ${loadingData ? 'animate-spin' : ''}`} aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Date range picker */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {([
+          { id: '1w', label: '1 week' },
+          { id: '2w', label: '2 weeks' },
+          { id: '1m', label: '1 month' },
+          { id: '3m', label: '3 months' },
+          { id: 'custom', label: 'Custom' },
+        ] as { id: DatePreset; label: string }[]).map(p => (
+          <button
+            key={p.id}
+            onClick={() => setPreset(p.id)}
+            className={`px-3 py-1.5 text-xs rounded-lg border transition-all ${
+              preset === p.id
+                ? 'bg-brand/10 border-brand/30 text-brand-light font-medium'
+                : 'border-border text-zinc-500 hover:text-zinc-300 hover:border-zinc-500'
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
+        {preset === 'custom' && (
+          <div className="flex items-center gap-2 ml-2">
+            <input
+              type="date"
+              value={customStart}
+              onChange={e => setCustomStart(e.target.value)}
+              className="bg-surface-raised border border-border rounded-lg px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-brand/40"
+            />
+            <span className="text-xs text-zinc-600">to</span>
+            <input
+              type="date"
+              value={customEnd}
+              onChange={e => setCustomEnd(e.target.value)}
+              className="bg-surface-raised border border-border rounded-lg px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-brand/40"
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Summary stats */}
+      <div className="grid grid-cols-4 gap-3">
+        <div className="bg-surface rounded-xl border border-border/60 px-4 py-3">
+          <div className="flex items-center gap-2 text-zinc-500 mb-1">
+            <GitPullRequest className="w-3.5 h-3.5" aria-hidden="true" />
+            <span className="text-xs">PRs authored</span>
+          </div>
+          <p className="text-xl font-semibold text-zinc-100">{loadingData ? '...' : stats.totalPRs}</p>
+        </div>
+        <div className="bg-surface rounded-xl border border-border/60 px-4 py-3">
+          <div className="flex items-center gap-2 text-zinc-500 mb-1">
+            <GitPullRequest className="w-3.5 h-3.5" aria-hidden="true" />
+            <span className="text-xs">PRs reviewed</span>
+          </div>
+          <p className="text-xl font-semibold text-zinc-100">{loadingData ? '...' : stats.totalReviews}</p>
+        </div>
+        <div className="bg-surface rounded-xl border border-border/60 px-4 py-3">
+          <div className="flex items-center gap-2 text-zinc-500 mb-1">
+            <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
+            <span className="text-xs">Feedback given</span>
+          </div>
+          <p className="text-xl font-semibold text-zinc-100">{loadingData ? '...' : stats.totalFeedback}</p>
+        </div>
+        <div className="bg-surface rounded-xl border border-border/60 px-4 py-3">
+          <div className="flex items-center gap-2 text-zinc-500 mb-1">
+            <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+            <span className="text-xs">Open actions</span>
+          </div>
+          <p className="text-xl font-semibold text-zinc-100">{loadingData ? '...' : stats.totalActions}</p>
+        </div>
+      </div>
+
+      {loadingData && members.length === 0 && (
+        <div className="flex items-center justify-center py-12 gap-2 text-zinc-500">
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          <span className="text-sm">Loading team data...</span>
+        </div>
+      )}
+
+      {members.length > 0 && (
+        <>
+          {/* PR Activity Chart */}
+          <div className="bg-surface rounded-xl border border-border/60 p-5">
+            <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+              <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
+              PR activity over time
+            </h2>
+            <ActivityChart members={members} startDate={startDate} endDate={endDate} />
+          </div>
+
+          {/* Feedback Balance Chart */}
+          <div className="bg-surface rounded-xl border border-border/60 p-5">
+            <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+              <MessageSquare className="w-4 h-4 text-brand-light" aria-hidden="true" />
+              Feedback balance
+            </h2>
+            <FeedbackChart members={members} />
+          </div>
+
+          {/* Team Roster */}
+          <div>
+            <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+              <Users className="w-4 h-4 text-brand-light" aria-hidden="true" />
+              Team roster
+            </h2>
+            <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+              {members.map(m => (
+                <RosterCard
+                  key={m.report.name}
+                  report={m.report}
+                  activity={m.activity}
+                  feedback={m.feedback}
+                  navigate={navigate}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/pages/Team.tsx
+++ b/src/renderer/pages/Team.tsx
@@ -94,13 +94,23 @@ function aggregateActivityByWeek(
   return { buckets, people: Array.from(people).sort() }
 }
 
+// ── Stable color mapping (alphabetical by name) ──
+
+function buildColorMap(members: TeamMemberDashboard[]): Record<string, string> {
+  const names = members.map(m => m.report.displayName).sort()
+  const map: Record<string, string> = {}
+  names.forEach((name, i) => { map[name] = COLORS[i % COLORS.length] })
+  return map
+}
+
 // ── SVG Line Chart (reusable for authored OR reviewed) ──
 
-function LineChart({ members, startDate, endDate, mode }: {
+function LineChart({ members, startDate, endDate, mode, colorMap }: {
   members: TeamMemberDashboard[]
   startDate: string
   endDate: string
   mode: 'authored' | 'reviewed'
+  colorMap: Record<string, string>
 }) {
   const { buckets, people } = useMemo(
     () => aggregateActivityByWeek(members, startDate, endDate),
@@ -143,8 +153,8 @@ function LineChart({ members, startDate, endDate, mode }: {
         {buckets.map((b, i) => (
           <text key={b.weekStart} x={pL + i * xStep} y={height - 6} textAnchor="middle" className="fill-zinc-600" fontSize={9}>{b.label}</text>
         ))}
-        {people.map((person, pi) => {
-          const color = COLORS[pi % COLORS.length]
+        {people.map((person) => {
+          const color = colorMap[person] ?? '#94a3b8'
           const points = buckets.map((b, i) => {
             const d = b.byPerson[person]
             const val = d ? d[mode] : 0
@@ -173,9 +183,9 @@ function LineChart({ members, startDate, endDate, mode }: {
           style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}>{tooltip.content}</div>
       )}
       <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 px-1">
-        {people.map((person, pi) => (
+        {people.map((person) => (
           <div key={person} className="flex items-center gap-1.5">
-            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: COLORS[pi % COLORS.length] }} />
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: colorMap[person] ?? '#94a3b8' }} />
             <span className="text-[11px] text-zinc-400">{person.split(' ')[0]}</span>
           </div>
         ))}
@@ -186,9 +196,10 @@ function LineChart({ members, startDate, endDate, mode }: {
 
 // ── Pie Chart (reusable for authored OR reviewed totals) ──
 
-function PieChart({ members, mode }: {
+function PieChart({ members, mode, colorMap }: {
   members: TeamMemberDashboard[]
   mode: 'authored' | 'reviewed'
+  colorMap: Record<string, string>
 }) {
   const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null)
 
@@ -209,11 +220,11 @@ function PieChart({ members, mode }: {
     return <div className="py-6 text-center text-sm text-zinc-500">No data</div>
   }
 
-  const size = 160
-  const cx = size / 2, cy = size / 2, r = 60
+  const size = 140
+  const cx = size / 2, cy = size / 2, r = 56
 
   let cumAngle = -Math.PI / 2
-  const slices = data.map((d, i) => {
+  const slices = data.map((d) => {
     const angle = (d.count / total) * Math.PI * 2
     const startAngle = cumAngle
     cumAngle += angle
@@ -226,11 +237,11 @@ function PieChart({ members, mode }: {
     const path = data.length === 1
       ? `M ${cx} ${cy - r} A ${r} ${r} 0 1 1 ${cx - 0.001} ${cy - r} Z`
       : `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`
-    return { ...d, path, color: COLORS[i % COLORS.length], pct: Math.round((d.count / total) * 100) }
+    return { ...d, path, color: colorMap[d.name] ?? '#94a3b8', pct: Math.round((d.count / total) * 100) }
   })
 
   return (
-    <div className="relative flex items-center gap-4">
+    <div className="relative flex flex-col items-center gap-3">
       <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} className="shrink-0">
         {slices.map((s, i) => (
           <path key={i} d={s.path} fill={s.color} fillOpacity={0.75} stroke="#111113" strokeWidth={1.5}
@@ -242,8 +253,6 @@ function PieChart({ members, mode }: {
             onMouseLeave={() => setTooltip(null)}
           />
         ))}
-        <text x={cx} y={cy - 4} textAnchor="middle" className="fill-zinc-200" fontSize={18} fontWeight={600}>{total}</text>
-        <text x={cx} y={cy + 12} textAnchor="middle" className="fill-zinc-500" fontSize={9}>{mode}</text>
       </svg>
       {tooltip && (
         <div className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
@@ -471,6 +480,9 @@ export function Team() {
     if (reports.length > 0) fetchDashboardData()
   }, [reports.length, startDate, endDate]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Stable color map for consistent person→color across all charts ──
+  const colorMap = useMemo(() => buildColorMap(members), [members])
+
   // ── Summary stats ──
   const stats = useMemo(() => {
     let totalPRs = 0, totalReviews = 0, totalFeedback = 0, totalActions = 0
@@ -600,39 +612,38 @@ export function Team() {
 
       {members.length > 0 && (
         <>
-          {/* PR Pie Charts — side by side */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="bg-surface rounded-xl border border-border/60 p-5">
-              <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
-                <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
-                PRs authored
-              </h2>
-              <PieChart members={members} mode="authored" />
-            </div>
-            <div className="bg-surface rounded-xl border border-border/60 p-5">
-              <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
-                <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
-                PRs reviewed
-              </h2>
-              <PieChart members={members} mode="reviewed" />
-            </div>
-          </div>
-
-          {/* PR Activity Line Charts — separate authored and reviewed */}
+          {/* PRs Authored — line chart (3/4) + pie chart (1/4) */}
           <div className="bg-surface rounded-xl border border-border/60 p-5">
             <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
               <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
-              PRs authored over time
+              PRs authored
+              <span className="text-zinc-500 font-normal">· {stats.totalPRs} total</span>
             </h2>
-            <LineChart members={members} startDate={startDate} endDate={endDate} mode="authored" />
+            <div className="flex gap-6 items-start">
+              <div className="flex-1 min-w-0">
+                <LineChart members={members} startDate={startDate} endDate={endDate} mode="authored" colorMap={colorMap} />
+              </div>
+              <div className="w-48 shrink-0">
+                <PieChart members={members} mode="authored" colorMap={colorMap} />
+              </div>
+            </div>
           </div>
 
+          {/* PRs Reviewed — line chart (3/4) + pie chart (1/4) */}
           <div className="bg-surface rounded-xl border border-border/60 p-5">
             <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
               <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
-              PRs reviewed over time
+              PRs reviewed
+              <span className="text-zinc-500 font-normal">· {stats.totalReviews} total</span>
             </h2>
-            <LineChart members={members} startDate={startDate} endDate={endDate} mode="reviewed" />
+            <div className="flex gap-6 items-start">
+              <div className="flex-1 min-w-0">
+                <LineChart members={members} startDate={startDate} endDate={endDate} mode="reviewed" colorMap={colorMap} />
+              </div>
+              <div className="w-48 shrink-0">
+                <PieChart members={members} mode="reviewed" colorMap={colorMap} />
+              </div>
+            </div>
           </div>
 
           {/* Feedback Balance Chart */}

--- a/src/renderer/pages/Team.tsx
+++ b/src/renderer/pages/Team.tsx
@@ -417,6 +417,35 @@ function RosterCard({ report, activity, feedback, navigate }: {
   )
 }
 
+// ── Dashboard data cache (persists across navigations) ──
+
+interface DashboardCacheEntry {
+  data: TeamMemberDashboard[]
+  fetchedAt: number
+}
+
+const _dashboardCache = new Map<string, DashboardCacheEntry>()
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+function getCachedDashboard(key: string): TeamMemberDashboard[] | null {
+  const entry = _dashboardCache.get(key)
+  if (!entry) return null
+  if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) {
+    _dashboardCache.delete(key)
+    return null
+  }
+  return entry.data
+}
+
+function setCachedDashboard(key: string, data: TeamMemberDashboard[]): void {
+  _dashboardCache.set(key, { data, fetchedAt: Date.now() })
+}
+
+/** Clear the dashboard cache (used by tests) */
+export function clearDashboardCache(): void {
+  _dashboardCache.clear()
+}
+
 // ── Main Team Page ──
 
 export function Team() {
@@ -445,8 +474,26 @@ export function Team() {
     return { startDate: start, endDate: end }
   }, [preset, customStart, customEnd])
 
-  const fetchDashboardData = useCallback(async () => {
+  const cacheKey = `${startDate}:${endDate}:${reports.map(r => r.name).join(',')}`
+
+  // Restore from cache on mount or date change
+  useEffect(() => {
+    const cached = getCachedDashboard(cacheKey)
+    if (cached) setMembers(cached)
+  }, [cacheKey])
+
+  const fetchDashboardData = useCallback(async (bypassCache = false) => {
     if (!reports.length) return
+
+    // Use cache if available and not bypassing
+    if (!bypassCache) {
+      const cached = getCachedDashboard(cacheKey)
+      if (cached) {
+        setMembers(cached)
+        return
+      }
+    }
+
     setLoadingData(true)
 
     try {
@@ -468,13 +515,14 @@ export function Team() {
         })
       )
       setMembers(results)
+      setCachedDashboard(cacheKey, results)
     } catch (e) {
       console.error('Failed to fetch team dashboard data:', e)
       toast.error('Failed to load team data')
     } finally {
       setLoadingData(false)
     }
-  }, [reports.length, startDate, endDate, toast])
+  }, [reports, startDate, endDate, cacheKey, toast])
 
   useEffect(() => {
     if (reports.length > 0) fetchDashboardData()
@@ -522,7 +570,7 @@ export function Team() {
           </p>
         </div>
         <button
-          onClick={fetchDashboardData}
+          onClick={() => fetchDashboardData(true)}
           disabled={loadingData}
           className="p-2 text-zinc-500 hover:text-zinc-300 hover:bg-white/[0.04] rounded-lg transition-colors disabled:opacity-50"
           aria-label="Refresh"

--- a/src/renderer/pages/Team.tsx
+++ b/src/renderer/pages/Team.tsx
@@ -94,12 +94,13 @@ function aggregateActivityByWeek(
   return { buckets, people: Array.from(people).sort() }
 }
 
-// ── SVG Chart with hover tooltips ──
+// ── SVG Line Chart (reusable for authored OR reviewed) ──
 
-function ActivityChart({ members, startDate, endDate }: {
+function LineChart({ members, startDate, endDate, mode }: {
   members: TeamMemberDashboard[]
   startDate: string
   endDate: string
+  mode: 'authored' | 'reviewed'
 }) {
   const { buckets, people } = useMemo(
     () => aggregateActivityByWeek(members, startDate, endDate),
@@ -108,21 +109,18 @@ function ActivityChart({ members, startDate, endDate }: {
   const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null)
 
   if (people.length === 0) {
-    return <div className="py-8 text-center text-sm text-zinc-500">No PR activity in this period</div>
+    return <div className="py-6 text-center text-sm text-zinc-500">No PR activity in this period</div>
   }
 
-  const width = 700
-  const height = 200
-  const pL = 36, pR = 16, pT = 16, pB = 36
-  const cW = width - pL - pR
-  const cH = height - pT - pB
+  const width = 700, height = 180
+  const pL = 36, pR = 16, pT = 16, pB = 32
+  const cW = width - pL - pR, cH = height - pT - pB
   const xStep = cW / Math.max(buckets.length - 1, 1)
 
-  // Per-person line data (not stacked — individual lines are easier to read)
   const maxVal = Math.max(1, ...buckets.map(b =>
     Math.max(...people.map(p => {
       const d = b.byPerson[p]
-      return d ? d.authored + d.reviewed : 0
+      return d ? d[mode] : 0
     }))
   ))
 
@@ -133,7 +131,6 @@ function ActivityChart({ members, startDate, endDate }: {
   return (
     <div className="relative">
       <svg viewBox={`0 0 ${width} ${height}`} className="w-full">
-        {/* Grid */}
         {yTicks.map(v => {
           const y = pT + cH - (v / maxVal) * cH
           return (
@@ -143,68 +140,121 @@ function ActivityChart({ members, startDate, endDate }: {
             </g>
           )
         })}
-
-        {/* X labels */}
         {buckets.map((b, i) => (
-          <text key={b.weekStart} x={pL + i * xStep} y={height - 8} textAnchor="middle" className="fill-zinc-600" fontSize={9}>
-            {b.label}
-          </text>
+          <text key={b.weekStart} x={pL + i * xStep} y={height - 6} textAnchor="middle" className="fill-zinc-600" fontSize={9}>{b.label}</text>
         ))}
-
-        {/* Lines per person */}
         {people.map((person, pi) => {
           const color = COLORS[pi % COLORS.length]
           const points = buckets.map((b, i) => {
             const d = b.byPerson[person]
-            const val = d ? d.authored + d.reviewed : 0
+            const val = d ? d[mode] : 0
             return { x: pL + i * xStep, y: pT + cH - (val / maxVal) * cH, val }
           })
           const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
-
           return (
             <g key={person}>
               <path d={linePath} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeOpacity={0.8} />
-              {points.map((p, i) => (
-                <circle
-                  key={i}
-                  cx={p.x} cy={p.y} r={p.val > 0 ? 3.5 : 0}
-                  fill={color} fillOpacity={0.9}
-                  className="cursor-pointer"
+              {points.map((p, i) => p.val > 0 ? (
+                <circle key={i} cx={p.x} cy={p.y} r={3.5} fill={color} fillOpacity={0.9}
                   onMouseEnter={(e) => {
                     const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
                     if (!rect) return
-                    const authored = buckets[i].byPerson[person]?.authored ?? 0
-                    const reviewed = buckets[i].byPerson[person]?.reviewed ?? 0
-                    setTooltip({
-                      x: e.clientX - rect.left,
-                      y: e.clientY - rect.top - 40,
-                      content: `${person.split(' ')[0]}: ${authored} authored, ${reviewed} reviewed (${buckets[i].label})`
-                    })
+                    setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${person.split(' ')[0]}: ${p.val} ${mode} (${buckets[i].label})` })
                   }}
                   onMouseLeave={() => setTooltip(null)}
                 />
-              ))}
+              ) : null)}
             </g>
           )
         })}
       </svg>
-
-      {/* Tooltip */}
       {tooltip && (
-        <div
-          className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
-          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}
-        >
-          {tooltip.content}
-        </div>
+        <div className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
+          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}>{tooltip.content}</div>
       )}
-
-      {/* Legend */}
       <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 px-1">
         {people.map((person, pi) => (
           <div key={person} className="flex items-center gap-1.5">
             <div className="w-2 h-2 rounded-full" style={{ backgroundColor: COLORS[pi % COLORS.length] }} />
             <span className="text-[11px] text-zinc-400">{person.split(' ')[0]}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Pie Chart (reusable for authored OR reviewed totals) ──
+
+function PieChart({ members, mode }: {
+  members: TeamMemberDashboard[]
+  mode: 'authored' | 'reviewed'
+}) {
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null)
+
+  const data = useMemo(() => {
+    return members
+      .map(m => {
+        const items = m.activity?.items ?? []
+        const count = items.filter(i => i.type === 'pr' && (mode === 'authored' ? i.role === 'author' : i.role !== 'author')).length
+        return { name: m.report.displayName, count }
+      })
+      .filter(d => d.count > 0)
+      .sort((a, b) => b.count - a.count)
+  }, [members, mode])
+
+  const total = data.reduce((s, d) => s + d.count, 0)
+
+  if (total === 0) {
+    return <div className="py-6 text-center text-sm text-zinc-500">No data</div>
+  }
+
+  const size = 160
+  const cx = size / 2, cy = size / 2, r = 60
+
+  let cumAngle = -Math.PI / 2
+  const slices = data.map((d, i) => {
+    const angle = (d.count / total) * Math.PI * 2
+    const startAngle = cumAngle
+    cumAngle += angle
+    const endAngle = cumAngle
+    const x1 = cx + r * Math.cos(startAngle)
+    const y1 = cy + r * Math.sin(startAngle)
+    const x2 = cx + r * Math.cos(endAngle)
+    const y2 = cy + r * Math.sin(endAngle)
+    const largeArc = angle > Math.PI ? 1 : 0
+    const path = data.length === 1
+      ? `M ${cx} ${cy - r} A ${r} ${r} 0 1 1 ${cx - 0.001} ${cy - r} Z`
+      : `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`
+    return { ...d, path, color: COLORS[i % COLORS.length], pct: Math.round((d.count / total) * 100) }
+  })
+
+  return (
+    <div className="relative flex items-center gap-4">
+      <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} className="shrink-0">
+        {slices.map((s, i) => (
+          <path key={i} d={s.path} fill={s.color} fillOpacity={0.75} stroke="#111113" strokeWidth={1.5}
+            onMouseEnter={(e) => {
+              const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
+              if (!rect) return
+              setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${s.name}: ${s.count} (${s.pct}%)` })
+            }}
+            onMouseLeave={() => setTooltip(null)}
+          />
+        ))}
+        <text x={cx} y={cy - 4} textAnchor="middle" className="fill-zinc-200" fontSize={18} fontWeight={600}>{total}</text>
+        <text x={cx} y={cy + 12} textAnchor="middle" className="fill-zinc-500" fontSize={9}>{mode}</text>
+      </svg>
+      {tooltip && (
+        <div className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
+          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}>{tooltip.content}</div>
+      )}
+      <div className="flex flex-col gap-1">
+        {slices.map((s, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: s.color }} />
+            <span className="text-[11px] text-zinc-400">{s.name.split(' ')[0]}</span>
+            <span className="text-[10px] text-zinc-600">{s.count} ({s.pct}%)</span>
           </div>
         ))}
       </div>
@@ -231,87 +281,69 @@ function FeedbackChart({ members }: { members: TeamMemberDashboard[] }) {
   const maxTotal = Math.max(1, ...data.map(d => d.total))
 
   if (data.every(d => d.total === 0)) {
-    return <div className="py-8 text-center text-sm text-zinc-500">No feedback in this period</div>
+    return <div className="py-6 text-center text-sm text-zinc-500">No feedback in this period</div>
   }
 
-  const barHeight = 28
-  const gap = 6
-  const labelWidth = 80
-  const chartWidth = 400
-  const totalHeight = data.length * (barHeight + gap)
+  const barH = 20, gap = 8, labelW = 70, chartW = 350
+  const totalH = data.length * (barH + gap)
+
+  function handleHover(e: React.MouseEvent<SVGRectElement>, text: string) {
+    const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
+    if (!rect) return
+    setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 36, content: text })
+  }
 
   return (
     <div className="relative">
-      <svg viewBox={`0 0 ${labelWidth + chartWidth + 40} ${totalHeight}`} className="w-full">
+      <svg viewBox={`0 0 ${labelW + chartW + 40} ${totalH}`} className="w-full" style={{ maxHeight: Math.max(totalH * 1.5, 120) }}>
         {data.map((d, i) => {
-          const y = i * (barHeight + gap)
-          const posW = (d.positive / maxTotal) * chartWidth
-          const conW = (d.constructive / maxTotal) * chartWidth
-          const othW = (d.other / maxTotal) * chartWidth
+          const y = i * (barH + gap)
+          const posW = (d.positive / maxTotal) * chartW
+          const conW = (d.constructive / maxTotal) * chartW
+          const othW = (d.other / maxTotal) * chartW
+          const totalW = posW + conW + othW
 
           return (
             <g key={d.name}>
-              <text x={labelWidth - 8} y={y + barHeight / 2 + 4} textAnchor="end" className="fill-zinc-400" fontSize={11}>
+              <text x={labelW - 6} y={y + barH / 2 + 4} textAnchor="end" className="fill-zinc-500" fontSize={10}>
                 {d.name.split(' ')[0]}
               </text>
-              {/* Positive */}
-              <rect
-                x={labelWidth} y={y + 2} width={Math.max(posW, 0)} height={barHeight - 4}
-                rx={4} fill="#34d399" fillOpacity={0.7}
-                className="cursor-pointer"
-                onMouseEnter={(e) => {
-                  const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
-                  if (!rect) return
-                  setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${d.name}: ${d.positive} positive` })
-                }}
-                onMouseLeave={() => setTooltip(null)}
-              />
-              {/* Constructive */}
-              <rect
-                x={labelWidth + posW} y={y + 2} width={Math.max(conW, 0)} height={barHeight - 4}
-                rx={conW > 0 && posW === 0 ? 4 : 0} fill="#f59e0b" fillOpacity={0.7}
-                className="cursor-pointer"
-                onMouseEnter={(e) => {
-                  const rect = (e.target as SVGElement).closest('svg')?.getBoundingClientRect()
-                  if (!rect) return
-                  setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top - 40, content: `${d.name}: ${d.constructive} constructive` })
-                }}
-                onMouseLeave={() => setTooltip(null)}
-              />
-              {/* Other */}
-              {othW > 0 && (
-                <rect
-                  x={labelWidth + posW + conW} y={y + 2} width={Math.max(othW, 0)} height={barHeight - 4}
-                  rx={0} fill="#94a3b8" fillOpacity={0.5}
-                />
-              )}
-              {/* Count */}
-              <text x={labelWidth + posW + conW + othW + 6} y={y + barHeight / 2 + 4} className="fill-zinc-600" fontSize={10}>
-                {d.total}
-              </text>
+              {/* Background track */}
+              <rect x={labelW} y={y + 1} width={chartW} height={barH - 2} rx={3} fill="rgba(255,255,255,0.02)" />
+              {/* Clip path for rounded ends */}
+              <clipPath id={`bar-clip-${i}`}>
+                <rect x={labelW} y={y + 1} width={Math.max(totalW, 1)} height={barH - 2} rx={3} />
+              </clipPath>
+              <g clipPath={`url(#bar-clip-${i})`}>
+                {posW > 0 && (
+                  <rect x={labelW} y={y + 1} width={posW} height={barH - 2} fill="#34d399" fillOpacity={0.7}
+                    onMouseEnter={(e) => handleHover(e, `${d.name}: ${d.positive} positive`)}
+                    onMouseLeave={() => setTooltip(null)} />
+                )}
+                {conW > 0 && (
+                  <rect x={labelW + posW} y={y + 1} width={conW} height={barH - 2} fill="#f59e0b" fillOpacity={0.7}
+                    onMouseEnter={(e) => handleHover(e, `${d.name}: ${d.constructive} constructive`)}
+                    onMouseLeave={() => setTooltip(null)} />
+                )}
+                {othW > 0 && (
+                  <rect x={labelW + posW + conW} y={y + 1} width={othW} height={barH - 2} fill="#94a3b8" fillOpacity={0.5}
+                    onMouseEnter={(e) => handleHover(e, `${d.name}: ${d.other} other`)}
+                    onMouseLeave={() => setTooltip(null)} />
+                )}
+              </g>
+              <text x={labelW + totalW + 6} y={y + barH / 2 + 4} className="fill-zinc-600" fontSize={9}>{d.total}</text>
             </g>
           )
         })}
       </svg>
-
       {tooltip && (
-        <div
-          className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
-          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}
-        >
-          {tooltip.content}
-        </div>
+        <div className="absolute pointer-events-none z-10 px-2.5 py-1.5 bg-zinc-800 border border-border rounded-lg text-xs text-zinc-200 shadow-lg whitespace-nowrap"
+          style={{ left: tooltip.x, top: tooltip.y, transform: 'translateX(-50%)' }}>{tooltip.content}</div>
       )}
-
       <div className="flex gap-4 mt-2 px-1">
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-emerald-400" />
-          <span className="text-[11px] text-zinc-400">Positive</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <div className="w-2 h-2 rounded-full bg-amber-400" />
-          <span className="text-[11px] text-zinc-400">Constructive</span>
-        </div>
+        <div className="flex items-center gap-1.5"><div className="w-2 h-2 rounded-full bg-emerald-400" /><span className="text-[11px] text-zinc-400">Positive</span></div>
+        <div className="flex items-center gap-1.5"><div className="w-2 h-2 rounded-full bg-amber-400" /><span className="text-[11px] text-zinc-400">Constructive</span></div>
+        <div className="flex items-center gap-1.5"><div className="w-2 h-2 rounded-full bg-slate-400" /><span className="text-[11px] text-zinc-400">Other</span></div>
       </div>
     </div>
   )
@@ -568,13 +600,39 @@ export function Team() {
 
       {members.length > 0 && (
         <>
-          {/* PR Activity Chart */}
+          {/* PR Pie Charts — side by side */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-surface rounded-xl border border-border/60 p-5">
+              <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+                <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
+                PRs authored
+              </h2>
+              <PieChart members={members} mode="authored" />
+            </div>
+            <div className="bg-surface rounded-xl border border-border/60 p-5">
+              <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+                <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
+                PRs reviewed
+              </h2>
+              <PieChart members={members} mode="reviewed" />
+            </div>
+          </div>
+
+          {/* PR Activity Line Charts — separate authored and reviewed */}
           <div className="bg-surface rounded-xl border border-border/60 p-5">
             <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
               <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
-              PR activity over time
+              PRs authored over time
             </h2>
-            <ActivityChart members={members} startDate={startDate} endDate={endDate} />
+            <LineChart members={members} startDate={startDate} endDate={endDate} mode="authored" />
+          </div>
+
+          <div className="bg-surface rounded-xl border border-border/60 p-5">
+            <h2 className="text-sm font-medium text-zinc-300 mb-3 flex items-center gap-2">
+              <GitPullRequest className="w-4 h-4 text-brand-light" aria-hidden="true" />
+              PRs reviewed over time
+            </h2>
+            <LineChart members={members} startDate={startDate} endDate={endDate} mode="reviewed" />
           </div>
 
           {/* Feedback Balance Chart */}

--- a/tests/renderer/Team.test.tsx
+++ b/tests/renderer/Team.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import ReactDOM from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Mocks ──
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() }
+vi.mock('../../src/renderer/components/common/Toast', () => ({ useToast: () => mockToast }))
+
+const mockOverview = {
+  reports: [
+    {
+      name: 'alice-smith', displayName: 'Alice Smith', github: 'alicesmith',
+      lastOneOnOne: '2026-03-25', daysGap: 13, openActionItems: 3,
+      status: 'on-track' as const, meetingDay: 'Tuesday',
+      lastCheckIn: '2026-03', lastFeedback: '2026-03-20',
+      feedbackCount: 5, checkInCount: 3
+    },
+    {
+      name: 'bob-jones', displayName: 'Bob Jones', github: 'bobjones',
+      lastOneOnOne: null, daysGap: 999, openActionItems: 0,
+      status: 'at-risk' as const,
+      lastCheckIn: null, lastFeedback: null,
+      feedbackCount: 0, checkInCount: 0
+    }
+  ],
+  attentionItems: [],
+  lastUpdated: '2026-04-07'
+}
+
+vi.mock('../../src/renderer/hooks/useData', () => ({
+  useTeamOverview: () => ({ overview: mockOverview, loading: false, error: null, refresh: vi.fn() }),
+  useSettings: () => ({ settings: {} })
+}))
+
+const mockFetchActivity = vi.fn()
+const mockGetReportData = vi.fn()
+
+import { Team } from '../../src/renderer/pages/Team'
+
+describe('Team page', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { configurable: true, value: true, writable: true })
+    document.body.innerHTML = ''
+    mockNavigate.mockReset()
+    mockToast.success.mockReset()
+    mockToast.error.mockReset()
+    mockFetchActivity.mockReset()
+    mockGetReportData.mockReset()
+
+    mockFetchActivity.mockResolvedValue({
+      reportName: 'alice-smith',
+      displayName: 'Alice Smith',
+      githubUsername: 'alicesmith',
+      items: [
+        { id: 1, type: 'pr', title: 'Fix bug', url: '', repo: 'org/repo', state: 'merged', createdAt: '2026-04-01T10:00:00Z', updatedAt: '2026-04-01T10:00:00Z', comments: 2, labels: [], role: 'author' },
+        { id: 2, type: 'pr', title: 'Review PR', url: '', repo: 'org/repo', state: 'merged', createdAt: '2026-04-02T10:00:00Z', updatedAt: '2026-04-02T10:00:00Z', comments: 1, labels: [], role: 'commenter' },
+        { id: 3, type: 'issue', title: 'File issue', url: '', repo: 'org/repo', state: 'open', createdAt: '2026-04-03T10:00:00Z', updatedAt: '2026-04-03T10:00:00Z', comments: 0, labels: [] },
+      ],
+      startDate: '2026-03-08',
+      endDate: '2026-04-07',
+      fetchedAt: '2026-04-07T12:00:00Z'
+    })
+
+    mockGetReportData.mockResolvedValue({
+      name: 'alice-smith',
+      profile: { displayName: 'Alice Smith', github: 'alicesmith', role: 'SWE', team: '', location: '', about: '', meetingDay: '', timezone: '', manager: '', startDate: '', communicationPreferences: {} },
+      feedback: [
+        { date: '2026-03-15', type: 'positive', source: 'manual', content: 'Great PR reviews' },
+        { date: '2026-03-20', type: 'constructive', source: 'manual', content: 'Could communicate blockers earlier' },
+        { date: '2026-02-01', type: 'positive', source: 'manual', content: 'Outside date range' },
+      ],
+      checkIns: [], summaries: [], transcripts: [], actionItems: [], reviews: [], preps: [], contextNotes: [], jobExpectations: ''
+    })
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        fetchActivityForPerson: mockFetchActivity,
+        getReportData: mockGetReportData,
+        getTeamOverview: vi.fn().mockResolvedValue(mockOverview),
+        getSettings: vi.fn().mockResolvedValue({}),
+      }
+    })
+  })
+
+  async function renderTeam() {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = ReactDOM.createRoot(container)
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/team']}>
+          <Team />
+        </MemoryRouter>
+      )
+    })
+    // Wait for data loading
+    await act(async () => { await new Promise(r => setTimeout(r, 100)) })
+    return { container, root }
+  }
+
+  it('renders the page header with report count', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('Team')
+    expect(container.textContent).toContain('2 reports')
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows date range preset buttons', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('1 week')
+    expect(container.textContent).toContain('2 weeks')
+    expect(container.textContent).toContain('1 month')
+    expect(container.textContent).toContain('3 months')
+    expect(container.textContent).toContain('Custom')
+    await act(async () => { root.unmount() })
+  })
+
+  it('fetches activity for each report on mount', async () => {
+    const { root } = await renderTeam()
+    expect(mockFetchActivity).toHaveBeenCalledTimes(2)
+    expect(mockGetReportData).toHaveBeenCalledTimes(2)
+    // First call should be alice-smith
+    expect(mockFetchActivity).toHaveBeenCalledWith('alice-smith', expect.any(String), expect.any(String))
+    expect(mockFetchActivity).toHaveBeenCalledWith('bob-jones', expect.any(String), expect.any(String))
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows summary stat cards', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('PRs authored')
+    expect(container.textContent).toContain('PRs reviewed')
+    expect(container.textContent).toContain('Feedback given')
+    expect(container.textContent).toContain('Open actions')
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows PR activity chart section', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('PR activity over time')
+    // Should have an SVG element
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows feedback balance chart section', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('Feedback balance')
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows team roster with report cards', async () => {
+    const { container, root } = await renderTeam()
+    expect(container.textContent).toContain('Team roster')
+    expect(container.textContent).toContain('Alice Smith')
+    expect(container.textContent).toContain('Bob Jones')
+    await act(async () => { root.unmount() })
+  })
+
+  it('roster cards show status information', async () => {
+    const { container, root } = await renderTeam()
+    // Alice has 3 open actions
+    expect(container.textContent).toContain('3 actions')
+    // Alice has PR data: 1 authored, 1 reviewed
+    expect(container.textContent).toContain('1a / 1r')
+    await act(async () => { root.unmount() })
+  })
+
+  it('filters feedback to selected date range', async () => {
+    const { container, root } = await renderTeam()
+    // Default is 1 month, so Mar 8 - Apr 7
+    // Should include Mar 15 and Mar 20 feedback, but not Feb 01
+    // The "2" count appears in feedback balance
+    expect(container.textContent).toContain('2') // 2 feedback in range
+    await act(async () => { root.unmount() })
+  })
+
+  it('clicking a roster card navigates to report page', async () => {
+    const { container, root } = await renderTeam()
+    const aliceCard = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Alice Smith') && b.textContent?.includes('actions'))
+    expect(aliceCard).toBeDefined()
+    await act(async () => { aliceCard?.click() })
+    expect(mockNavigate).toHaveBeenCalledWith('/report/alice-smith')
+    await act(async () => { root.unmount() })
+  })
+
+  it('changing date preset refetches data', async () => {
+    const { container, root } = await renderTeam()
+    mockFetchActivity.mockClear()
+    mockGetReportData.mockClear()
+
+    const weekButton = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === '1 week')
+    await act(async () => {
+      weekButton?.click()
+      await new Promise(r => setTimeout(r, 100))
+    })
+
+    expect(mockFetchActivity).toHaveBeenCalled()
+    await act(async () => { root.unmount() })
+  })
+
+  it('shows custom date inputs when Custom is selected', async () => {
+    const { container, root } = await renderTeam()
+    const customButton = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === 'Custom')
+    await act(async () => { customButton?.click() })
+
+    const dateInputs = container.querySelectorAll('input[type="date"]')
+    expect(dateInputs.length).toBeGreaterThanOrEqual(2)
+    await act(async () => { root.unmount() })
+  })
+
+  it('handles API errors gracefully', async () => {
+    mockFetchActivity.mockRejectedValue(new Error('Network error'))
+    mockGetReportData.mockRejectedValue(new Error('Network error'))
+
+    const { container, root } = await renderTeam()
+    // Should not crash — roster still shows from overview data
+    expect(container.textContent).toContain('Team')
+    await act(async () => { root.unmount() })
+  })
+})

--- a/tests/renderer/Team.test.tsx
+++ b/tests/renderer/Team.test.tsx
@@ -44,10 +44,11 @@ vi.mock('../../src/renderer/hooks/useData', () => ({
 const mockFetchActivity = vi.fn()
 const mockGetReportData = vi.fn()
 
-import { Team } from '../../src/renderer/pages/Team'
+import { Team, clearDashboardCache } from '../../src/renderer/pages/Team'
 
 describe('Team page', () => {
   beforeEach(() => {
+    clearDashboardCache()
     Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', { configurable: true, value: true, writable: true })
     document.body.innerHTML = ''
     mockNavigate.mockReset()

--- a/tests/renderer/Team.test.tsx
+++ b/tests/renderer/Team.test.tsx
@@ -146,7 +146,10 @@ describe('Team page', () => {
 
   it('shows PR activity chart section', async () => {
     const { container, root } = await renderTeam()
-    expect(container.textContent).toContain('PR activity over time')
+    expect(container.textContent).toContain('PRs authored over time')
+    expect(container.textContent).toContain('PRs reviewed over time')
+    expect(container.textContent).toContain('PRs authored') // pie chart
+    expect(container.textContent).toContain('PRs reviewed') // pie chart
     // Should have an SVG element
     const svg = container.querySelector('svg')
     expect(svg).not.toBeNull()

--- a/tests/renderer/Team.test.tsx
+++ b/tests/renderer/Team.test.tsx
@@ -146,8 +146,8 @@ describe('Team page', () => {
 
   it('shows PR activity chart section', async () => {
     const { container, root } = await renderTeam()
-    expect(container.textContent).toContain('PRs authored over time')
-    expect(container.textContent).toContain('PRs reviewed over time')
+    expect(container.textContent).toContain('PRs authored')
+    expect(container.textContent).toContain('PRs reviewed')
     expect(container.textContent).toContain('PRs authored') // pie chart
     expect(container.textContent).toContain('PRs reviewed') // pie chart
     // Should have an SVG element


### PR DESCRIPTION
## What

New **/team** page (⌘2) providing a team-wide analytics dashboard.

## Features

- **Date range picker** — presets (1w, 2w, 1m, 3m) and custom date inputs. All charts and stats filter to the selected range.
- **Summary stat cards** — PRs authored, PRs reviewed, feedback given, open actions.
- **PR activity line chart** — SVG lines per person with hover tooltips showing exact counts per week.
- **Feedback balance chart** — horizontal stacked bars (positive vs constructive) per person with hover tooltips.
- **Team roster grid** — card per person with avatar, status dot, last 1:1, open actions, PR counts, feedback count. Clickable → navigates to report page.

## Technical

- Pure SVG charts with no external charting library
- Data fetched in parallel via existing `fetchActivityForPerson` + `getReportData` APIs — no new backend methods needed
- Sidebar nav entry added between Today and Playbook, shortcuts bumped (⌘2=Team, ⌘3=Playbook, etc.)
- 13 new tests covering rendering, data fetching, date filtering, navigation, error handling

## Testing

```
866 tests passing (58 files)
```