### PR TITLE
Match Settings PAT description to onboarding + validate on save

### DIFF
--- a/src/renderer/pages/Settings.tsx
+++ b/src/renderer/pages/Settings.tsx
@@ -24,7 +24,9 @@ import {
   Lightbulb,
   ArrowDown,
   UserPlus,
-  RefreshCw
+  RefreshCw,
+  ExternalLink,
+  Loader2
 } from 'lucide-react'
 import { PROMPT_TEMPLATES } from '../../shared/prompts'
 import { GitHubMark } from '../components/common/GitHubMark'
@@ -67,6 +69,7 @@ export function Settings() {
   const [savedGithubOrgToken, setSavedGithubOrgToken] = useState('')
   const [showOrgToken, setShowOrgToken] = useState(false)
   const [hasGithubOrgToken, setHasGithubOrgToken] = useState(false)
+  const [tokenWarning, setTokenWarning] = useState('')
   const [repoPathError, setRepoPathError] = useState('')
   const [activePromptTab, setActivePromptTab] = useState(PROMPT_TEMPLATES[0].id)
   const [userNameVal, setUserNameVal] = useState('')
@@ -141,7 +144,19 @@ export function Settings() {
   const handleSave = async () => {
     if (saving) return
     setSaving(true)
+    setTokenWarning('')
     try {
+      // Validate new token before saving
+      if (githubOrgToken.trim()) {
+        try {
+          const valid = await window.api.validateGithubToken(githubOrgToken.trim())
+          if (!valid) {
+            setTokenWarning('Token could not be validated — it may not have the required permissions. Saved anyway; you can update it later.')
+          }
+        } catch (e) {
+          console.debug('Token validation failed (network/IPC issue):', e)
+        }
+      }
       const allSettings = { 
         repoPath: repoPathVal, 
         defaultModel: model, 
@@ -674,13 +689,30 @@ export function Settings() {
                 {showOrgToken ? <EyeOff className="w-4 h-4" aria-hidden="true" /> : <Eye className="w-4 h-4" aria-hidden="true" />}
               </button>
             </div>
-            <p className="text-xs text-zinc-600 mt-2">
-              Used to show team PR/issue activity in the Today view. Stored locally, only sent to the GitHub API.
-            </p>
-            <p className="text-xs text-zinc-600 mt-1">
-              <strong className="text-zinc-500">Fine-grained:</strong> read-only access to Organization → Members and your org's repos.{' '}
-              <strong className="text-zinc-500">Classic:</strong> <code className="bg-surface-raised px-1 rounded">read:org</code> + <code className="bg-surface-raised px-1 rounded">repo</code> scopes.
-            </p>
+            <div className="mt-2.5 space-y-1.5 text-xs text-zinc-500">
+              <p>This token lets the app read your team's activity (PRs, issues, discussions). It is stored locally, encrypted on disk, and never sent anywhere except the GitHub API.</p>
+              <p className="text-zinc-600">
+                <strong className="text-zinc-500">Create a fine-grained PAT under your organization</strong> (not your personal account) with <strong className="text-zinc-500">read-only</strong> access to:
+              </p>
+              <ul className="list-disc list-inside text-zinc-600 space-y-0.5 pl-1">
+                <li>Contents</li>
+                <li>Discussions</li>
+                <li>Issues</li>
+                <li>Pull requests</li>
+              </ul>
+            </div>
+            <a
+              href={githubOrgName.trim()
+                ? `https://github.com/organizations/${githubOrgName.trim()}/settings/personal-access-tokens/new`
+                : 'https://github.com/settings/tokens?type=beta'}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 mt-2 text-xs text-brand-light hover:text-brand transition-colors"
+            >
+              <ExternalLink className="w-3 h-3" aria-hidden="true" />
+              Create a fine-grained token {githubOrgName.trim() ? `for ${githubOrgName.trim()}` : 'on GitHub'}
+            </a>
+            {tokenWarning && <p className="text-xs text-amber-400 mt-2">{tokenWarning}</p>}
           </div>
         </div>
       </section>


### PR DESCRIPTION
The Settings page PAT section now matches the onboarding screen:

- Detailed instructions: create a **fine-grained PAT under your organization** with read-only access to Contents, Discussions, Issues, Pull requests
- Direct link to create token on GitHub (org-specific URL when org name is set)
- Token is validated via `validateGithubToken` when saving — shows amber warning if invalid (still saves so users aren't blocked)

857 tests passing.