### PR TITLE
Remove 'manager's records only' warning from check-in prompts

### DIFF
--- a/src/main/copilot.ts
+++ b/src/main/copilot.ts
@@ -433,8 +433,6 @@ Use this format:
 # Monthly check-in: ${context.month}
 _${context.displayName}, ${context.monthName}_
 
-> ⚠️ This document is for manager's records only.
-
 ## Accomplishments
 ## Concerns
 ## Goal progress

--- a/src/shared/prompts.ts
+++ b/src/shared/prompts.ts
@@ -96,8 +96,6 @@ Use this format:
 # Monthly check-in: {month}
 _{displayName}, {monthName}_
 
-> ⚠️ This document is for manager's records only.
-
 ## Accomplishments
 ## Concerns
 ## Goal progress


### PR DESCRIPTION
Supersedes #34 (which had massive merge conflicts after #33 landed). All check-ins are meant to be shared, so the warning line is misleading. Removed from both `src/shared/prompts.ts` and `src/main/copilot.ts`.