### PR TITLE
Add Plans page: iteration-by-iteration capacity planning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,18 @@
 
 ## Recent Changes (April 2026)
 
+### Plans page (April 2026)
+- New `/plans` and `/plans/:slug` routes with sidebar entry (LayoutGrid icon, ⌘4).
+- Iteration-by-iteration capacity planner: rows = people, columns grouped under iterations (each iteration = 1+ "week" columns), bottom table = projects.
+- Click any cell to open a popover and pick projects to assign; OR drag a project chip from the projects table onto a cell.
+- Each project has: color (11-color palette), name, DRI dropdown (people in plan), est. weeks (number), URL (e.g. GitHub issue), and an auto-calculated `planned / estimated wk` counter that turns emerald when planned == estimated and amber when over.
+- Plans are stored as `plans/<slug>.json` in the data repo (so they're git-versioned and sync via the normal commit flow).
+- Adding a person opens a dialog that lists the manager's direct reports (those not already on the plan) plus a custom-name option.
+- Adding an iteration auto-generates two consecutive Mon-Fri week labels (e.g. "Jan 5-9", "Jan 12-16"), continuing from the latest existing column. All labels are inline-editable.
+- Debounced 600 ms autosave with inline "Saving / Saved" indicator.
+- New IPC: `plans:list`, `plans:get`, `plans:create`, `plans:save`, `plans:delete`. Storage in `src/main/plans.ts`.
+- Tests: `tests/main/plans.test.ts` (13), `tests/renderer/Plans.test.tsx` (4), `tests/renderer/PlanDetail.test.tsx` (5), `tests/renderer/planColors.test.ts` (8).
+
 ### Per-direct-report repo sync + transcript cleanup (COMPLETE)
 Two related features shipped together so that managers can keep their main repo as the source of truth while still pushing curated content to per-report private repos.
 

--- a/src/main/github.ts
+++ b/src/main/github.ts
@@ -157,6 +157,10 @@ function listFiles(path: string): string[] {
   } catch { return [] }
 }
 
+export function listFilesInDir(path: string): string[] {
+  return listFiles(path)
+}
+
 function listFilesRecursive(path: string): string[] {
   const results: string[] = []
   const stack: string[] = [path]

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -48,6 +48,8 @@ import { getTeamActivity, getMonthlyActivityForPerson, fetchActivityForPerson, s
 import { detectTeam } from './hubbers'
 import { detectExternalApps, openInVSCode, openInObsidian, revealInFinder, openInGitHub } from './external'
 import { getRepoSyncStatus, previewSync, syncReport } from './syncToReport'
+import { listPlans, getPlan, createPlan, savePlan, deletePlan } from './plans'
+import type { Plan } from '../shared/types'
 
 /** Wrap an IPC handler so any thrown error is forwarded as a descriptive Error to the renderer */
 function safeHandle(
@@ -297,6 +299,13 @@ export function setupIpcHandlers(): void {
   safeHandle('report:sync', (event, slug) => syncReport(slug as string, (p) => {
     safeSend(BrowserWindow.fromWebContents(event.sender), 'report:sync-progress', p)
   }))
+
+  // ── Plans ──
+  safeHandle('plans:list', () => listPlans())
+  safeHandle('plans:get', (_e, slug) => getPlan(slug as string))
+  safeHandle('plans:create', (_e, name) => createPlan(name as string))
+  safeHandle('plans:save', (_e, plan) => savePlan(plan as Plan))
+  safeHandle('plans:delete', (_e, slug) => deletePlan(slug as string))
 
   // ── Test-only IPC handlers for E2E setup ──
   if (process.env['ELECTRON_USER_DATA']) {

--- a/src/main/plans.ts
+++ b/src/main/plans.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from 'crypto'
+import {
+  getFileContent,
+  fileExists,
+  commitFile,
+  deleteFile as deleteRepoFile,
+  listFilesInDir,
+} from './github'
+import type { Plan, PlanSummary } from '../shared/types'
+
+const PLANS_DIR = 'plans'
+
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+}
+
+function planPath(slug: string): string {
+  return `${PLANS_DIR}/${slug}.json`
+}
+
+export function listPlans(): PlanSummary[] {
+  const files = listFilesInDir(PLANS_DIR).filter(f => f.endsWith('.json'))
+  const out: PlanSummary[] = []
+  for (const f of files) {
+    try {
+      const raw = getFileContent(`${PLANS_DIR}/${f}`)
+      const p = JSON.parse(raw) as Plan
+      out.push({ slug: p.slug, name: p.name, updatedAt: p.updatedAt })
+    } catch {}
+  }
+  return out.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+}
+
+export function getPlan(slug: string): Plan | null {
+  const path = planPath(slug)
+  if (!fileExists(path)) return null
+  try {
+    const raw = getFileContent(path)
+    const plan = JSON.parse(raw) as Plan
+    return normalizePlan(plan)
+  } catch {
+    return null
+  }
+}
+
+function normalizePlan(plan: Plan): Plan {
+  return {
+    ...plan,
+    iterations: Array.isArray(plan.iterations) ? plan.iterations : [],
+    people: Array.isArray(plan.people) ? plan.people : [],
+    projects: Array.isArray(plan.projects) ? plan.projects : [],
+    assignments: Array.isArray(plan.assignments) ? plan.assignments : [],
+  }
+}
+
+function uniqueSlug(base: string): string {
+  let slug = base || 'plan'
+  let i = 2
+  while (fileExists(planPath(slug))) {
+    slug = `${base}-${i++}`
+  }
+  return slug
+}
+
+export async function createPlan(name: string): Promise<Plan> {
+  const trimmed = name.trim() || 'Untitled plan'
+  const baseSlug = slugify(trimmed) || 'plan'
+  const slug = uniqueSlug(baseSlug)
+  const now = new Date().toISOString()
+  const plan: Plan = {
+    slug,
+    name: trimmed,
+    iterations: [],
+    people: [],
+    projects: [],
+    assignments: [],
+    createdAt: now,
+    updatedAt: now,
+  }
+  await commitFile(planPath(slug), JSON.stringify(plan, null, 2), `Create plan: ${trimmed}`)
+  return plan
+}
+
+export async function savePlan(plan: Plan): Promise<void> {
+  if (!plan.slug) throw new Error('Plan slug is required')
+  const next: Plan = normalizePlan({ ...plan, updatedAt: new Date().toISOString() })
+  // Strip orphaned assignments referencing nonexistent column/person/project
+  const colIds = new Set(next.iterations.flatMap(it => it.columns.map(c => c.id)))
+  const personIds = new Set(next.people.map(p => p.id))
+  const projectIds = new Set(next.projects.map(p => p.id))
+  next.assignments = next.assignments.filter(
+    a => colIds.has(a.columnId) && personIds.has(a.personId) && projectIds.has(a.projectId)
+  )
+  await commitFile(planPath(next.slug), JSON.stringify(next, null, 2), `Update plan: ${next.name}`)
+}
+
+export async function deletePlan(slug: string): Promise<void> {
+  const path = planPath(slug)
+  if (!fileExists(path)) return
+  await deleteRepoFile(path)
+}
+
+// Re-export for tests / convenience
+export const __test = { slugify, uniqueSlug, normalizePlan, planPath }
+
+export function newId(): string {
+  return randomUUID()
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -184,5 +184,12 @@ contextBridge.exposeInMainWorld('api', {
     const handler = () => cb()
     ipcRenderer.on('find:prev', handler)
     return () => ipcRenderer.removeListener('find:prev', handler)
-  }
+  },
+
+  // Plans
+  listPlans: () => ipcRenderer.invoke('plans:list'),
+  getPlan: (slug: string) => ipcRenderer.invoke('plans:get', slug),
+  createPlan: (name: string) => ipcRenderer.invoke('plans:create', name),
+  savePlan: (plan: unknown) => ipcRenderer.invoke('plans:save', plan),
+  deletePlan: (slug: string) => ipcRenderer.invoke('plans:delete', slug)
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -16,6 +16,8 @@ import tieIcon from '../../resources/tie.png'
 const ReportDetail = lazy(() => import('./pages/ReportDetail').then(m => ({ default: m.ReportDetail })))
 const Playbook = lazy(() => import('./pages/Playbook').then(m => ({ default: m.Playbook })))
 const TeamPage = lazy(() => import('./pages/Team').then(m => ({ default: m.Team })))
+const Plans = lazy(() => import('./pages/Plans').then(m => ({ default: m.Plans })))
+const PlanDetail = lazy(() => import('./pages/PlanDetail').then(m => ({ default: m.PlanDetail })))
 
 const Settings = lazy(() => import('./pages/Settings').then(m => ({ default: m.Settings })))
 const ContextDetail = lazy(() => import('./pages/ContextDetail').then(m => ({ default: m.ContextDetail })))
@@ -97,6 +99,8 @@ export default function App() {
       children: [
         { path: '/', element: <Today /> },
         { path: '/team', element: <TeamPage /> },
+        { path: '/plans', element: <Plans /> },
+        { path: '/plans/:slug', element: <PlanDetail /> },
         { path: '/playbook', element: <Playbook /> },
         { path: '/chat', element: <Chat /> },
         { path: '/report/:name', element: <ReportDetail /> },

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -12,7 +12,8 @@ import {
   Keyboard,
   Plus,
   RefreshCw,
-  Users
+  Users,
+  LayoutGrid
 } from 'lucide-react'
 import { useTeamOverview, useSettings } from '../../hooks/useData'
 import { useAuth } from '../../hooks/useAuth'
@@ -33,8 +34,9 @@ const navItems = [
   { path: '/', icon: Sun, label: 'Today', shortcut: 'cmd+1' },
   { path: '/playbook', icon: BookOpen, label: 'Playbook', shortcut: 'cmd+2' },
   { path: '/team', icon: Users, label: 'Team', shortcut: 'cmd+3' },
-  { path: '/chat', icon: MessageSquare, label: 'Chat', shortcut: 'cmd+4' },
-  { path: '/search', icon: Search, label: 'Search', shortcut: 'cmd+5' }
+  { path: '/plans', icon: LayoutGrid, label: 'Plans', shortcut: 'cmd+4' },
+  { path: '/chat', icon: MessageSquare, label: 'Chat', shortcut: 'cmd+5' },
+  { path: '/search', icon: Search, label: 'Search', shortcut: 'cmd+6' }
 ]
 
 export function AppShell({ children }: AppShellProps) {
@@ -171,7 +173,7 @@ export function AppShell({ children }: AppShellProps) {
         e.preventDefault()
         setShortcutsOpen(prev => !prev)
       }
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '5') {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key >= '1' && e.key <= '6') {
         const idx = parseInt(e.key) - 1
         if (navItems[idx]) {
           e.preventDefault()

--- a/src/renderer/components/plan/AssignCellPopover.tsx
+++ b/src/renderer/components/plan/AssignCellPopover.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react'
+import { PLAN_COLOR_THEMES } from '../../utils/planColors'
+import type { Plan, PlanProject } from '../../../shared/types'
+
+interface Props {
+  open: boolean
+  anchor: { x: number; y: number } | null
+  plan: Plan
+  selectedProjectIds: string[]
+  onSelectProject: (projectId: string) => void
+  onRemoveProject: (projectId: string) => void
+  onClose: () => void
+  onCreateProject: () => void
+}
+
+export function AssignCellPopover({ open, anchor, plan, selectedProjectIds, onSelectProject, onRemoveProject, onClose, onCreateProject }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    // Defer so the opening click doesn't immediately dismiss
+    const t = setTimeout(() => document.addEventListener('mousedown', onClick), 0)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onClick)
+      clearTimeout(t)
+    }
+  }, [open, onClose])
+
+  if (!open || !anchor) return null
+
+  // Position popover near the anchor; clamp to viewport
+  const top = Math.min(anchor.y + 4, window.innerHeight - 360)
+  const left = Math.min(anchor.x, window.innerWidth - 280)
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Assign project"
+      className="fixed z-50 w-[260px] rounded-lg bg-zinc-900 border border-white/10 shadow-2xl shadow-black/50 p-2 animate-fade-in"
+      style={{ top, left }}
+    >
+      <div className="text-[10px] font-semibold text-zinc-500 uppercase tracking-wider px-2 pt-1 pb-1.5">
+        Assign project
+      </div>
+      <div className="max-h-[280px] overflow-y-auto -mx-1 px-1">
+        {plan.projects.length === 0 && (
+          <div className="px-2 py-3 text-xs text-zinc-500 italic">
+            No projects yet. Add one below.
+          </div>
+        )}
+        {plan.projects.map(p => {
+          const checked = selectedProjectIds.includes(p.id)
+          return (
+            <ProjectPickerRow
+              key={p.id}
+              project={p}
+              checked={checked}
+              onToggle={() => (checked ? onRemoveProject(p.id) : onSelectProject(p.id))}
+            />
+          )
+        })}
+      </div>
+      <div className="border-t border-white/[0.06] mt-1 pt-1">
+        <button
+          onClick={() => { onCreateProject(); onClose() }}
+          className="w-full text-left px-2 py-1.5 text-xs text-zinc-400 hover:text-brand-light hover:bg-white/[0.04] rounded transition-colors"
+        >
+          + New project…
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ProjectPickerRow({ project, checked, onToggle }: { project: PlanProject; checked: boolean; onToggle: () => void }) {
+  const theme = PLAN_COLOR_THEMES[project.color]
+  return (
+    <button
+      onClick={onToggle}
+      className={`w-full flex items-center gap-2 px-2 py-1.5 rounded text-left transition-colors ${checked ? 'bg-white/[0.06]' : 'hover:bg-white/[0.04]'}`}
+    >
+      <span className={`w-3 h-3 rounded-full shrink-0 ${theme.swatch}`} />
+      <span className="flex-1 text-sm text-zinc-200 truncate">{project.name || 'Untitled'}</span>
+      {checked && <span className="text-xs text-brand-light shrink-0">✓</span>}
+    </button>
+  )
+}

--- a/src/renderer/components/plan/ColorSwatchPicker.tsx
+++ b/src/renderer/components/plan/ColorSwatchPicker.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check } from 'lucide-react'
+import { PLAN_COLOR_PALETTE, PLAN_COLOR_THEMES } from '../../utils/planColors'
+import type { PlanColor } from '../../../shared/types'
+
+interface Props {
+  value: PlanColor
+  onChange: (color: PlanColor) => void
+}
+
+export function ColorSwatchPicker({ value, onChange }: Props) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const theme = PLAN_COLOR_THEMES[value]
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
+    const t = setTimeout(() => document.addEventListener('mousedown', onClick), 0)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+      clearTimeout(t)
+    }
+  }, [open])
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className={`w-5 h-5 rounded-full ${theme.swatch} ring-1 ring-white/20 hover:ring-2 hover:ring-white/40 transition-all`}
+        aria-label="Change color"
+        title="Change color"
+      />
+      {open && (
+        <div className="absolute z-30 top-7 left-0 p-2 rounded-lg bg-zinc-900 border border-white/10 shadow-xl shadow-black/50 grid grid-cols-6 gap-1.5 animate-fade-in">
+          {PLAN_COLOR_PALETTE.map(c => {
+            const t = PLAN_COLOR_THEMES[c]
+            const isCurrent = c === value
+            return (
+              <button
+                key={c}
+                onClick={() => { onChange(c); setOpen(false) }}
+                className={`w-5 h-5 rounded-full ${t.swatch} flex items-center justify-center hover:scale-110 transition-transform ${isCurrent ? `ring-2 ${t.selectedRing} ring-offset-2 ring-offset-zinc-900` : 'ring-1 ring-white/10'}`}
+                aria-label={c}
+                title={c}
+              >
+                {isCurrent && <Check className="w-3 h-3 text-white" strokeWidth={3} aria-hidden="true" />}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/plan/PlanGrid.tsx
+++ b/src/renderer/components/plan/PlanGrid.tsx
@@ -1,0 +1,374 @@
+import { useMemo, useState } from 'react'
+import { X, Plus } from 'lucide-react'
+import { PLAN_COLOR_THEMES } from '../../utils/planColors'
+import { AssignCellPopover } from './AssignCellPopover'
+import type { Plan, PlanIteration, PlanPerson } from '../../../shared/types'
+
+interface Props {
+  plan: Plan
+  onChange: (next: Plan) => void
+  onAddPerson: () => void
+  onAddIteration: () => void
+  onAddProject: () => void
+  /** Project being dragged from the projects table (for drop-on-cell) */
+  draggedProjectId: string | null
+  setDraggedProjectId: (id: string | null) => void
+}
+
+export function PlanGrid({
+  plan,
+  onChange,
+  onAddPerson,
+  onAddIteration,
+  onAddProject,
+  draggedProjectId,
+  setDraggedProjectId,
+}: Props) {
+  const [activeCell, setActiveCell] = useState<{ personId: string; columnId: string; anchor: { x: number; y: number } } | null>(null)
+  const [hoverCell, setHoverCell] = useState<string | null>(null) // `${personId}:${columnId}`
+
+  const cellAssignments = useMemo(() => {
+    const map = new Map<string, string[]>()
+    for (const a of plan.assignments) {
+      const k = `${a.personId}:${a.columnId}`
+      if (!map.has(k)) map.set(k, [])
+      map.get(k)!.push(a.projectId)
+    }
+    return map
+  }, [plan.assignments])
+
+  const projectById = useMemo(() => {
+    const m = new Map<string, Plan['projects'][number]>()
+    for (const p of plan.projects) m.set(p.id, p)
+    return m
+  }, [plan.projects])
+
+  const removeIteration = (id: string) => {
+    const removed = plan.iterations.find(i => i.id === id)
+    if (!removed) return
+    const colIds = new Set(removed.columns.map(c => c.id))
+    onChange({
+      ...plan,
+      iterations: plan.iterations.filter(i => i.id !== id),
+      assignments: plan.assignments.filter(a => !colIds.has(a.columnId)),
+    })
+  }
+
+  const removePerson = (id: string) => {
+    onChange({
+      ...plan,
+      people: plan.people.filter(p => p.id !== id),
+      assignments: plan.assignments.filter(a => a.personId !== id),
+      projects: plan.projects.map(p => p.driPersonId === id ? { ...p, driPersonId: undefined } : p),
+    })
+  }
+
+  const updateColumnLabel = (columnId: string, label: string) => {
+    onChange({
+      ...plan,
+      iterations: plan.iterations.map(it => ({
+        ...it,
+        columns: it.columns.map(c => c.id === columnId ? { ...c, label } : c),
+      })),
+    })
+  }
+
+  const updateIterationName = (iterationId: string, name: string) => {
+    onChange({
+      ...plan,
+      iterations: plan.iterations.map(it => it.id === iterationId ? { ...it, name } : it),
+    })
+  }
+
+  const updatePersonName = (personId: string, name: string) => {
+    onChange({
+      ...plan,
+      people: plan.people.map(p => p.id === personId ? { ...p, name } : p),
+    })
+  }
+
+  const assignProject = (personId: string, columnId: string, projectId: string) => {
+    if (plan.assignments.some(a => a.personId === personId && a.columnId === columnId && a.projectId === projectId)) return
+    onChange({
+      ...plan,
+      assignments: [...plan.assignments, { personId, columnId, projectId }],
+    })
+  }
+
+  const unassignProject = (personId: string, columnId: string, projectId: string) => {
+    onChange({
+      ...plan,
+      assignments: plan.assignments.filter(
+        a => !(a.personId === personId && a.columnId === columnId && a.projectId === projectId)
+      ),
+    })
+  }
+
+  const flatColumns = plan.iterations.flatMap(it => it.columns)
+  const totalCols = flatColumns.length
+
+  // Grid template: first col = person name (180px), then equal columns for each week
+  const gridTemplate = `180px repeat(${Math.max(totalCols, 1)}, minmax(110px, 1fr))`
+
+  return (
+    <div className="rounded-xl bg-surface border border-border overflow-hidden">
+      {/* Header bar with add buttons */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-zinc-900/40">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Plan</div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onAddIteration}
+            className="px-3 py-1.5 text-xs font-medium bg-white/[0.04] hover:bg-white/[0.08] text-zinc-200 rounded-md transition-colors border border-white/[0.06]"
+          >
+            + Iteration
+          </button>
+          <button
+            onClick={onAddPerson}
+            className="px-3 py-1.5 text-xs font-medium bg-white/[0.04] hover:bg-white/[0.08] text-zinc-200 rounded-md transition-colors border border-white/[0.06]"
+          >
+            + Person
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <div style={{ minWidth: `calc(180px + ${Math.max(totalCols, 1)} * 110px)` }}>
+          {/* Iteration row */}
+          <div className="grid border-b border-border-subtle bg-zinc-900/30" style={{ gridTemplateColumns: gridTemplate }}>
+            <div className="px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-zinc-500 border-r border-border-subtle">
+              Person
+            </div>
+            {plan.iterations.length === 0 ? (
+              <div className="px-4 py-2 text-xs text-zinc-600 italic">No iterations yet — click + Iteration to add one.</div>
+            ) : (
+              plan.iterations.map(it => (
+                <IterationHeader
+                  key={it.id}
+                  iteration={it}
+                  span={it.columns.length}
+                  onRename={(name) => updateIterationName(it.id, name)}
+                  onRemove={() => removeIteration(it.id)}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Column-label row */}
+          {plan.iterations.length > 0 && (
+            <div className="grid border-b border-border bg-zinc-900/20" style={{ gridTemplateColumns: gridTemplate }}>
+              <div className="border-r border-border-subtle" />
+              {flatColumns.map(c => (
+                <input
+                  key={c.id}
+                  type="text"
+                  value={c.label}
+                  onChange={(e) => updateColumnLabel(c.id, e.target.value)}
+                  className="px-2 py-1.5 text-xs text-center text-zinc-400 bg-transparent border-0 border-r border-border-subtle focus:outline-none focus:bg-white/[0.04] focus:text-zinc-200 transition-colors"
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Body: one row per person */}
+          {plan.people.length === 0 ? (
+            <div className="px-4 py-10 text-center text-sm text-zinc-500">
+              No people on this plan yet. Click <span className="text-brand-light">+ Person</span> above.
+            </div>
+          ) : (
+            plan.people.map(person => (
+              <PersonRow
+                key={person.id}
+                person={person}
+                gridTemplate={gridTemplate}
+                columns={flatColumns}
+                cellAssignments={cellAssignments}
+                projectById={projectById}
+                hoverCell={hoverCell}
+                setHoverCell={setHoverCell}
+                draggedProjectId={draggedProjectId}
+                setDraggedProjectId={setDraggedProjectId}
+                onCellClick={(columnId, e) => setActiveCell({
+                  personId: person.id,
+                  columnId,
+                  anchor: { x: e.clientX, y: e.clientY }
+                })}
+                onUnassign={(columnId, projectId) => unassignProject(person.id, columnId, projectId)}
+                onDropProject={(columnId, projectId) => assignProject(person.id, columnId, projectId)}
+                onRename={(name) => updatePersonName(person.id, name)}
+                onRemove={() => removePerson(person.id)}
+              />
+            ))
+          )}
+
+          {/* Add-person footer row */}
+          <div className="grid" style={{ gridTemplateColumns: gridTemplate }}>
+            <button
+              onClick={onAddPerson}
+              className="text-left px-4 py-2.5 text-xs text-zinc-500 hover:text-brand-light hover:bg-white/[0.02] transition-colors border-r border-border-subtle"
+            >
+              + Add person
+            </button>
+            <div className="col-span-full" />
+          </div>
+        </div>
+      </div>
+
+      {activeCell && (
+        <AssignCellPopover
+          open={true}
+          anchor={activeCell.anchor}
+          plan={plan}
+          selectedProjectIds={cellAssignments.get(`${activeCell.personId}:${activeCell.columnId}`) || []}
+          onSelectProject={(pid) => assignProject(activeCell.personId, activeCell.columnId, pid)}
+          onRemoveProject={(pid) => unassignProject(activeCell.personId, activeCell.columnId, pid)}
+          onClose={() => setActiveCell(null)}
+          onCreateProject={onAddProject}
+        />
+      )}
+    </div>
+  )
+}
+
+function IterationHeader({ iteration, span, onRename, onRemove }: {
+  iteration: PlanIteration
+  span: number
+  onRename: (name: string) => void
+  onRemove: () => void
+}) {
+  return (
+    <div
+      className="relative px-2 py-1.5 border-r border-border-subtle bg-purple-500/[0.08] group flex items-center justify-center"
+      style={{ gridColumn: `span ${span} / span ${span}` }}
+    >
+      <input
+        type="text"
+        value={iteration.name || ''}
+        onChange={(e) => onRename(e.target.value)}
+        placeholder="Iteration"
+        className="bg-transparent border-0 text-xs text-purple-200 text-center focus:outline-none focus:bg-white/[0.04] rounded px-1 py-0.5 w-full"
+      />
+      <button
+        onClick={onRemove}
+        className="absolute top-0.5 right-0.5 opacity-0 group-hover:opacity-100 text-purple-300/60 hover:text-red-400 transition-all"
+        aria-label="Remove iteration"
+        title="Remove iteration"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    </div>
+  )
+}
+
+function PersonRow({
+  person,
+  gridTemplate,
+  columns,
+  cellAssignments,
+  projectById,
+  hoverCell,
+  setHoverCell,
+  draggedProjectId,
+  setDraggedProjectId,
+  onCellClick,
+  onUnassign,
+  onDropProject,
+  onRename,
+  onRemove,
+}: {
+  person: PlanPerson
+  gridTemplate: string
+  columns: { id: string; label: string }[]
+  cellAssignments: Map<string, string[]>
+  projectById: Map<string, Plan['projects'][number]>
+  hoverCell: string | null
+  setHoverCell: (key: string | null) => void
+  draggedProjectId: string | null
+  setDraggedProjectId: (id: string | null) => void
+  onCellClick: (columnId: string, e: React.MouseEvent) => void
+  onUnassign: (columnId: string, projectId: string) => void
+  onDropProject: (columnId: string, projectId: string) => void
+  onRename: (name: string) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="grid border-b border-border-subtle group/row" style={{ gridTemplateColumns: gridTemplate }}>
+      <div className="px-3 py-2 border-r border-border-subtle flex items-center gap-2 group/person">
+        {person.github ? (
+          <img src={`https://github.com/${person.github}.png?size=48`} alt="" className="w-6 h-6 rounded-full object-cover shrink-0" />
+        ) : (
+          <div className="w-6 h-6 rounded-full bg-zinc-800 text-zinc-400 text-[11px] font-semibold flex items-center justify-center shrink-0">
+            {person.name.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <input
+          type="text"
+          value={person.name}
+          onChange={(e) => onRename(e.target.value)}
+          className="bg-transparent border-0 text-sm text-zinc-200 focus:outline-none focus:bg-white/[0.04] rounded px-1 py-0.5 w-full min-w-0"
+        />
+        <button
+          onClick={onRemove}
+          className="opacity-0 group-hover/person:opacity-100 text-zinc-500 hover:text-red-400 transition-all shrink-0"
+          aria-label="Remove person"
+          title="Remove person"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+      {columns.map(c => {
+        const key = `${person.id}:${c.id}`
+        const assigned = cellAssignments.get(key) || []
+        const isHover = hoverCell === key
+        const isDragTarget = isHover && draggedProjectId
+        return (
+          <div
+            key={c.id}
+            onClick={(e) => onCellClick(c.id, e)}
+            onMouseEnter={() => setHoverCell(key)}
+            onMouseLeave={() => setHoverCell(null)}
+            onDragOver={(e) => {
+              if (e.dataTransfer.types.includes('application/x-plan-project')) {
+                e.preventDefault()
+                e.dataTransfer.dropEffect = 'copy'
+              }
+            }}
+            onDrop={(e) => {
+              const pid = e.dataTransfer.getData('application/x-plan-project')
+              if (!pid) return
+              e.preventDefault()
+              onDropProject(c.id, pid)
+              setDraggedProjectId(null)
+              setHoverCell(null)
+            }}
+            className={`min-h-[44px] px-1 py-1 border-r border-border-subtle flex flex-wrap content-start gap-1 cursor-pointer transition-colors ${
+              isDragTarget
+                ? 'bg-brand/15 ring-1 ring-inset ring-brand/40'
+                : isHover ? 'bg-white/[0.025]' : ''
+            }`}
+          >
+            {assigned.map(pid => {
+              const project = projectById.get(pid)
+              if (!project) return null
+              const theme = PLAN_COLOR_THEMES[project.color]
+              return (
+                <span
+                  key={pid}
+                  onClick={(e) => { e.stopPropagation(); onUnassign(c.id, pid) }}
+                  title={`${project.name} — click to remove`}
+                  className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium border cursor-pointer max-w-full ${theme.chip}`}
+                >
+                  <span className="truncate">{project.name || 'Untitled'}</span>
+                </span>
+              )
+            })}
+            {assigned.length === 0 && isHover && !draggedProjectId && (
+              <span className="text-zinc-700 text-[11px] flex items-center gap-1 px-1">
+                <Plus className="w-3 h-3" aria-hidden="true" /> assign
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/components/plan/ProjectsTable.tsx
+++ b/src/renderer/components/plan/ProjectsTable.tsx
@@ -1,0 +1,237 @@
+import { useMemo, useState, useCallback } from 'react'
+import { GripVertical, X, ExternalLink } from 'lucide-react'
+import { ColorSwatchPicker } from './ColorSwatchPicker'
+import { PLAN_COLOR_THEMES } from '../../utils/planColors'
+import type { Plan, PlanProject } from '../../../shared/types'
+
+interface Props {
+  plan: Plan
+  onChange: (next: Plan) => void
+  onAddProject: () => void
+  /** When user clicks a row, set this as the chip-being-dragged (so cells can drop) */
+  draggedProjectId: string | null
+  setDraggedProjectId: (id: string | null) => void
+}
+
+export function ProjectsTable({ plan, onChange, onAddProject, draggedProjectId, setDraggedProjectId }: Props) {
+  const planned = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const a of plan.assignments) {
+      counts[a.projectId] = (counts[a.projectId] || 0) + 1
+    }
+    return counts
+  }, [plan.assignments])
+
+  const updateProject = useCallback((id: string, patch: Partial<PlanProject>) => {
+    onChange({ ...plan, projects: plan.projects.map(p => p.id === id ? { ...p, ...patch } : p) })
+  }, [plan, onChange])
+
+  const removeProject = useCallback((id: string) => {
+    onChange({
+      ...plan,
+      projects: plan.projects.filter(p => p.id !== id),
+      assignments: plan.assignments.filter(a => a.projectId !== id),
+    })
+  }, [plan, onChange])
+
+  // Reorder via drag (within table only)
+  const [dragRowId, setDragRowId] = useState<string | null>(null)
+
+  const handleRowDragStart = (e: React.DragEvent, id: string) => {
+    setDragRowId(id)
+    e.dataTransfer.effectAllowed = 'move'
+    // Also empty data so cell drop won't trigger
+    e.dataTransfer.setData('text/plain', '__plan-row__')
+  }
+
+  const handleRowDragOver = (e: React.DragEvent) => {
+    if (dragRowId) e.preventDefault()
+  }
+
+  const handleRowDrop = (e: React.DragEvent, targetId: string) => {
+    if (!dragRowId || dragRowId === targetId) return
+    e.preventDefault()
+    const ids = plan.projects.map(p => p.id)
+    const from = ids.indexOf(dragRowId)
+    const to = ids.indexOf(targetId)
+    if (from < 0 || to < 0) return
+    const reordered = [...plan.projects]
+    const [moved] = reordered.splice(from, 1)
+    reordered.splice(to, 0, moved)
+    onChange({ ...plan, projects: reordered })
+    setDragRowId(null)
+  }
+
+  return (
+    <div className="rounded-xl bg-surface border border-border overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-border bg-zinc-900/40">
+        <div className="flex items-center gap-3">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">Projects</span>
+          <span className="text-xs text-zinc-600">Drag a chip onto a cell, or click a cell to pick.</span>
+        </div>
+        <button
+          onClick={onAddProject}
+          className="px-3 py-1.5 text-xs font-medium bg-brand hover:bg-brand-dark text-white rounded-md transition-colors"
+        >
+          + Add project
+        </button>
+      </div>
+
+      <div className="grid text-xs text-zinc-500 px-4 py-2 border-b border-border-subtle gap-3 items-center" style={{ gridTemplateColumns: 'auto auto 1fr 140px 80px 100px 1fr 24px' }}>
+        <span></span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">Color</span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">Name</span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">DRI</span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">Est. wk</span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">Planned</span>
+        <span className="uppercase tracking-wider text-[10px] font-semibold">URL</span>
+        <span></span>
+      </div>
+
+      <div>
+        {plan.projects.length === 0 && (
+          <div className="px-4 py-10 text-center text-sm text-zinc-500">
+            No projects yet. Click <span className="text-brand-light">+ Add project</span> to create one.
+          </div>
+        )}
+        {plan.projects.map(p => {
+          const planCount = planned[p.id] || 0
+          const est = p.estWeeks
+          const ratioClass = est == null
+            ? 'text-zinc-500'
+            : planCount === est
+              ? 'text-emerald-400'
+              : planCount > est
+                ? 'text-amber-300'
+                : planCount === 0
+                  ? 'text-zinc-500'
+                  : 'text-zinc-300'
+          const isBeingDragged = draggedProjectId === p.id
+          return (
+            <div
+              key={p.id}
+              draggable
+              onDragStart={(e) => handleRowDragStart(e, p.id)}
+              onDragOver={handleRowDragOver}
+              onDrop={(e) => handleRowDrop(e, p.id)}
+              onDragEnd={() => { setDragRowId(null); setDraggedProjectId(null) }}
+              className={`grid items-center gap-3 px-4 py-2 border-b border-border-subtle hover:bg-white/[0.02] transition-colors group ${isBeingDragged ? 'opacity-50' : ''}`}
+              style={{ gridTemplateColumns: 'auto auto 1fr 140px 80px 100px 1fr 24px' }}
+            >
+              <span className="text-zinc-600 cursor-grab active:cursor-grabbing" title="Drag to reorder">
+                <GripVertical className="w-4 h-4" aria-hidden="true" />
+              </span>
+
+              <ColorSwatchPicker value={p.color} onChange={(c) => updateProject(p.id, { color: c })} />
+
+              <DraggableNameCell
+                project={p}
+                onChangeName={(v) => updateProject(p.id, { name: v })}
+                onChipDragStart={() => setDraggedProjectId(p.id)}
+                onChipDragEnd={() => setDraggedProjectId(null)}
+              />
+
+              <select
+                value={p.driPersonId || ''}
+                onChange={(e) => updateProject(p.id, { driPersonId: e.target.value || undefined })}
+                className="bg-zinc-900 border border-border rounded-md px-2 py-1 text-sm text-zinc-300 focus:outline-none focus:border-brand transition-colors"
+              >
+                <option value="">—</option>
+                {plan.people.map(pp => (
+                  <option key={pp.id} value={pp.id}>{pp.name}</option>
+                ))}
+              </select>
+
+              <input
+                type="number"
+                min={0}
+                step={0.5}
+                value={p.estWeeks ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value
+                  updateProject(p.id, { estWeeks: v === '' ? null : Number(v) })
+                }}
+                className="bg-zinc-900 border border-border rounded-md px-2 py-1 text-sm text-zinc-300 w-full focus:outline-none focus:border-brand transition-colors"
+                placeholder="—"
+              />
+
+              <span className={`text-sm tabular-nums ${ratioClass}`}>
+                {est == null ? `${planCount} wk` : `${planCount} / ${est} wk`}
+              </span>
+
+              <UrlCell value={p.url || ''} onChange={(v) => updateProject(p.id, { url: v || undefined })} />
+
+              <button
+                onClick={() => removeProject(p.id)}
+                className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 transition-opacity"
+                aria-label="Delete project"
+                title="Delete project"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function DraggableNameCell({ project, onChangeName, onChipDragStart, onChipDragEnd }: {
+  project: PlanProject
+  onChangeName: (v: string) => void
+  onChipDragStart: () => void
+  onChipDragEnd: () => void
+}) {
+  const theme = PLAN_COLOR_THEMES[project.color]
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <span
+        draggable
+        onDragStart={(e) => {
+          e.stopPropagation()
+          e.dataTransfer.setData('application/x-plan-project', project.id)
+          e.dataTransfer.effectAllowed = 'copy'
+          onChipDragStart()
+        }}
+        onDragEnd={(e) => { e.stopPropagation(); onChipDragEnd() }}
+        className={`shrink-0 w-5 h-5 rounded-full border ${theme.chip} cursor-grab active:cursor-grabbing flex items-center justify-center`}
+        title="Drag onto a cell to assign"
+      >
+        <span className="text-[10px] opacity-60">⋮⋮</span>
+      </span>
+      <input
+        type="text"
+        value={project.name}
+        onChange={(e) => onChangeName(e.target.value)}
+        placeholder="Project name"
+        className="bg-transparent border-0 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-brand/40 rounded px-1.5 py-0.5 w-full min-w-0"
+      />
+    </div>
+  )
+}
+
+function UrlCell({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-1 min-w-0">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="https://github.com/.../issues/123"
+        className="bg-zinc-900 border border-border rounded-md px-2 py-1 text-xs text-zinc-300 w-full focus:outline-none focus:border-brand transition-colors min-w-0"
+      />
+      {value && (
+        <a
+          href={value}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-zinc-500 hover:text-brand-light transition-colors"
+          title="Open URL"
+        >
+          <ExternalLink className="w-3.5 h-3.5" aria-hidden="true" />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/pages/PlanDetail.tsx
+++ b/src/renderer/pages/PlanDetail.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ChevronLeft, Trash2, Plus } from 'lucide-react'
+import { useTeamOverview } from '../hooks/useData'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useToast } from '../components/common/Toast'
+import { ConfirmDialog } from '../components/common/ConfirmDialog'
+import { PlanGrid } from '../components/plan/PlanGrid'
+import { ProjectsTable } from '../components/plan/ProjectsTable'
+import { nextIterationLabels, nextUnusedColor } from '../utils/planColors'
+import type { Plan, PlanColor, PlanIteration, PlanPerson, PlanProject } from '../../shared/types'
+
+function uid(): string {
+  return Math.random().toString(36).slice(2, 11)
+}
+
+export function PlanDetail() {
+  const { slug = '' } = useParams()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const { overview } = useTeamOverview()
+  const reports = overview?.reports ?? []
+  const [plan, setPlan] = useState<Plan | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [draggedProjectId, setDraggedProjectId] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [savingState, setSavingState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [showAddPerson, setShowAddPerson] = useState(false)
+
+  useDocumentTitle(plan?.name || 'Plan')
+
+  useEffect(() => {
+    let cancel = false
+    setLoading(true)
+    window.api.getPlan(slug).then(p => {
+      if (cancel) return
+      setPlan(p)
+      setLoading(false)
+    }).catch(err => {
+      console.error('Failed to load plan', err)
+      if (!cancel) setLoading(false)
+    })
+    return () => { cancel = true }
+  }, [slug])
+
+  // Debounced save
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastSavedRef = useRef<string>('')
+  const handleChange = useCallback((next: Plan) => {
+    setPlan(next)
+    if (saveTimer.current) clearTimeout(saveTimer.current)
+    setSavingState('saving')
+    saveTimer.current = setTimeout(async () => {
+      try {
+        const serialized = JSON.stringify(next)
+        if (serialized === lastSavedRef.current) {
+          setSavingState('saved')
+          return
+        }
+        await window.api.savePlan(next)
+        lastSavedRef.current = serialized
+        setSavingState('saved')
+        setTimeout(() => setSavingState(s => s === 'saved' ? 'idle' : s), 1500)
+      } catch (err) {
+        console.error('Save failed', err)
+        setSavingState('error')
+        toast.error('Failed to save plan')
+      }
+    }, 600)
+  }, [toast])
+
+  useEffect(() => () => { if (saveTimer.current) clearTimeout(saveTimer.current) }, [])
+
+  // Initialize lastSavedRef when plan loads
+  useEffect(() => {
+    if (plan && !lastSavedRef.current) {
+      lastSavedRef.current = JSON.stringify(plan)
+    }
+  }, [plan])
+
+  const handleAddIteration = useCallback(() => {
+    if (!plan) return
+    const allLabels = plan.iterations.flatMap(it => it.columns.map(c => c.label))
+    const labels = nextIterationLabels(allLabels, 2)
+    const newIt: PlanIteration = {
+      id: uid(),
+      columns: labels.map(label => ({ id: uid(), label })),
+    }
+    handleChange({ ...plan, iterations: [...plan.iterations, newIt] })
+  }, [plan, handleChange])
+
+  const handleAddPersonFromReport = useCallback((reportName: string, displayName: string, github?: string) => {
+    if (!plan) return
+    const newPerson: PlanPerson = {
+      id: uid(),
+      name: displayName,
+      reportSlug: reportName,
+      github,
+    }
+    handleChange({ ...plan, people: [...plan.people, newPerson] })
+    setShowAddPerson(false)
+  }, [plan, handleChange])
+
+  const handleAddPersonCustom = useCallback((name: string) => {
+    if (!plan || !name.trim()) return
+    const newPerson: PlanPerson = { id: uid(), name: name.trim() }
+    handleChange({ ...plan, people: [...plan.people, newPerson] })
+    setShowAddPerson(false)
+  }, [plan, handleChange])
+
+  const handleAddProject = useCallback(() => {
+    if (!plan) return
+    const used = plan.projects.map(p => p.color)
+    const newProject: PlanProject = {
+      id: uid(),
+      name: '',
+      color: nextUnusedColor(used) as PlanColor,
+      estWeeks: null,
+    }
+    handleChange({ ...plan, projects: [...plan.projects, newProject] })
+    // Scroll to bottom of projects table after a tick so the new row is visible
+    setTimeout(() => {
+      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' })
+    }, 30)
+  }, [plan, handleChange])
+
+  const handleDelete = useCallback(async () => {
+    if (!plan) return
+    try {
+      await window.api.deletePlan(plan.slug)
+      toast.success('Plan deleted')
+      navigate('/plans', { replace: true })
+    } catch (err) {
+      console.error(err)
+      toast.error('Failed to delete plan')
+    }
+  }, [plan, navigate, toast])
+
+  const handleRename = useCallback((name: string) => {
+    if (!plan) return
+    handleChange({ ...plan, name })
+  }, [plan, handleChange])
+
+  const availableReports = useMemo(() => {
+    if (!plan) return []
+    const usedSlugs = new Set(plan.people.map(p => p.reportSlug).filter(Boolean) as string[])
+    return reports.filter(r => !usedSlugs.has(r.name))
+  }, [reports, plan])
+
+  if (loading) {
+    return <div className="max-w-7xl mx-auto p-8 text-zinc-500 text-sm">Loading plan…</div>
+  }
+
+  if (!plan) {
+    return (
+      <div className="max-w-3xl mx-auto p-8">
+        <button onClick={() => navigate('/plans')} className="text-sm text-zinc-400 hover:text-zinc-200 flex items-center gap-1">
+          <ChevronLeft className="w-4 h-4" aria-hidden="true" /> Plans
+        </button>
+        <div className="mt-6 p-8 rounded-xl bg-surface border border-border text-center">
+          <h2 className="text-lg font-semibold text-zinc-200 mb-2">Plan not found</h2>
+          <p className="text-sm text-zinc-500">It may have been deleted.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-[1400px] mx-auto pb-12 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <button
+            onClick={() => navigate('/plans')}
+            className="text-zinc-400 hover:text-zinc-200 transition-colors"
+            title="Back to plans"
+          >
+            <ChevronLeft className="w-5 h-5" aria-hidden="true" />
+          </button>
+          <input
+            type="text"
+            value={plan.name}
+            onChange={(e) => handleRename(e.target.value)}
+            placeholder="Untitled plan"
+            className="text-xl font-semibold bg-transparent border-0 text-zinc-100 focus:outline-none focus:ring-0 px-2 py-1 rounded hover:bg-white/[0.03] focus:bg-white/[0.05] transition-colors min-w-0 flex-1"
+          />
+          <SaveIndicator state={savingState} />
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setConfirmDelete(true)}
+            className="px-3 py-1.5 text-xs font-medium text-zinc-500 hover:text-red-400 hover:bg-red-500/10 rounded-md transition-colors flex items-center gap-1.5"
+            title="Delete plan"
+          >
+            <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+            Delete
+          </button>
+        </div>
+      </div>
+
+      <PlanGrid
+        plan={plan}
+        onChange={handleChange}
+        onAddPerson={() => setShowAddPerson(true)}
+        onAddIteration={handleAddIteration}
+        onAddProject={handleAddProject}
+        draggedProjectId={draggedProjectId}
+        setDraggedProjectId={setDraggedProjectId}
+      />
+
+      <ProjectsTable
+        plan={plan}
+        onChange={handleChange}
+        onAddProject={handleAddProject}
+        draggedProjectId={draggedProjectId}
+        setDraggedProjectId={setDraggedProjectId}
+      />
+
+      {showAddPerson && (
+        <AddPersonDialog
+          availableReports={availableReports}
+          onPickReport={handleAddPersonFromReport}
+          onPickCustom={handleAddPersonCustom}
+          onClose={() => setShowAddPerson(false)}
+        />
+      )}
+
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Delete plan?"
+        message={`Permanently delete "${plan.name}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  )
+}
+
+function SaveIndicator({ state }: { state: 'idle' | 'saving' | 'saved' | 'error' }) {
+  if (state === 'idle') return null
+  if (state === 'saving') return <span className="text-xs text-zinc-500">Saving…</span>
+  if (state === 'saved') return <span className="text-xs text-emerald-400">Saved</span>
+  return <span className="text-xs text-red-400">Save failed</span>
+}
+
+function AddPersonDialog({ availableReports, onPickReport, onPickCustom, onClose }: {
+  availableReports: { name: string; displayName: string; github?: string }[]
+  onPickReport: (reportName: string, displayName: string, github?: string) => void
+  onPickCustom: (name: string) => void
+  onClose: () => void
+}) {
+  const [custom, setCustom] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black/40 flex items-start justify-center pt-[12vh] animate-backdrop-fade" onClick={onClose}>
+      <div
+        ref={containerRef}
+        onClick={(e) => e.stopPropagation()}
+        className="w-[420px] bg-zinc-900 border border-white/10 rounded-xl shadow-2xl shadow-black/50 p-4 animate-scale-in"
+      >
+        <h3 className="text-sm font-semibold text-zinc-200 mb-3">Add person to plan</h3>
+        <div className="text-[11px] uppercase font-semibold tracking-wider text-zinc-500 mb-1.5">From your team</div>
+        <div className="max-h-[260px] overflow-y-auto -mx-1 px-1 space-y-0.5">
+          {availableReports.length === 0 && (
+            <div className="px-2 py-3 text-xs text-zinc-500 italic">All your reports are already on this plan.</div>
+          )}
+          {availableReports.map(r => (
+            <button
+              key={r.name}
+              onClick={() => onPickReport(r.name, r.displayName, r.github)}
+              className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-left hover:bg-white/[0.05] transition-colors"
+            >
+              {r.github ? (
+                <img src={`https://github.com/${r.github}.png?size=48`} alt="" className="w-6 h-6 rounded-full object-cover" />
+              ) : (
+                <div className="w-6 h-6 rounded-full bg-zinc-800 text-zinc-400 text-[11px] font-semibold flex items-center justify-center">
+                  {r.displayName.charAt(0).toUpperCase()}
+                </div>
+              )}
+              <span className="text-sm text-zinc-200">{r.displayName}</span>
+            </button>
+          ))}
+        </div>
+
+        <div className="border-t border-white/[0.06] mt-3 pt-3">
+          <div className="text-[11px] uppercase font-semibold tracking-wider text-zinc-500 mb-1.5">Or add a custom name</div>
+          <form
+            onSubmit={(e) => { e.preventDefault(); if (custom.trim()) onPickCustom(custom) }}
+            className="flex items-center gap-2"
+          >
+            <input
+              type="text"
+              value={custom}
+              onChange={(e) => setCustom(e.target.value)}
+              placeholder="e.g. cross-team partner"
+              className="flex-1 bg-zinc-800 border border-white/[0.06] rounded-md px-2.5 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-brand transition-colors"
+              autoFocus
+            />
+            <button
+              type="submit"
+              disabled={!custom.trim()}
+              className="px-3 py-1.5 text-xs font-medium bg-brand hover:bg-brand-dark disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-md transition-colors flex items-center gap-1"
+            >
+              <Plus className="w-3.5 h-3.5" aria-hidden="true" /> Add
+            </button>
+          </form>
+        </div>
+
+        <div className="flex justify-end mt-3">
+          <button onClick={onClose} className="text-xs text-zinc-400 hover:text-zinc-200 px-2 py-1 transition-colors">Cancel</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/pages/Plans.tsx
+++ b/src/renderer/pages/Plans.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { LayoutGrid, Plus, Calendar } from 'lucide-react'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useToast } from '../components/common/Toast'
+import type { PlanSummary } from '../../shared/types'
+
+export function Plans() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [plans, setPlans] = useState<PlanSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState('')
+
+  useDocumentTitle('Plans')
+
+  const load = useCallback(async () => {
+    try {
+      const list = await window.api.listPlans()
+      setPlans(list)
+    } catch (err) {
+      console.error('Failed to load plans', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const handleCreate = useCallback(async () => {
+    const name = newName.trim() || 'Untitled plan'
+    setCreating(true)
+    try {
+      const plan = await window.api.createPlan(name)
+      toast.success('Plan created')
+      navigate(`/plans/${plan.slug}`)
+    } catch (err) {
+      console.error(err)
+      toast.error('Failed to create plan')
+      setCreating(false)
+    }
+  }, [newName, navigate, toast])
+
+  return (
+    <div className="max-w-5xl mx-auto pt-2 pb-12">
+      <header className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-zinc-100 flex items-center gap-2">
+            <LayoutGrid className="w-6 h-6 text-brand-light" aria-hidden="true" /> Plans
+          </h1>
+          <p className="text-sm text-zinc-500 mt-1">Iteration-by-iteration plans for your team's work.</p>
+        </div>
+      </header>
+
+      {/* Create new */}
+      <div className="rounded-xl bg-surface border border-border p-4 mb-6">
+        <form
+          onSubmit={(e) => { e.preventDefault(); if (!creating) handleCreate() }}
+          className="flex items-center gap-2"
+        >
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="New plan name (e.g. FY26Q3 Roadmap)"
+            className="flex-1 bg-zinc-900 border border-border rounded-md px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-brand transition-colors"
+          />
+          <button
+            type="submit"
+            disabled={creating}
+            className="px-4 py-2 text-sm font-medium bg-brand hover:bg-brand-dark disabled:opacity-50 text-white rounded-md transition-colors flex items-center gap-1.5"
+          >
+            <Plus className="w-4 h-4" aria-hidden="true" />
+            Create plan
+          </button>
+        </form>
+      </div>
+
+      {/* Existing list */}
+      {loading ? (
+        <div className="text-sm text-zinc-500 px-1">Loading…</div>
+      ) : plans.length === 0 ? (
+        <div className="rounded-xl bg-surface border border-border p-10 text-center">
+          <Calendar className="w-10 h-10 text-zinc-700 mx-auto mb-3" aria-hidden="true" />
+          <h2 className="text-base font-semibold text-zinc-300 mb-1">No plans yet</h2>
+          <p className="text-sm text-zinc-500">
+            Create your first plan above. Plans live in your data repo so they're versioned and shareable.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-1">
+          {plans.map(p => (
+            <li key={p.slug}>
+              <button
+                onClick={() => navigate(`/plans/${p.slug}`)}
+                className="w-full flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-surface hover:bg-surface-raised border border-border hover:border-brand/30 transition-all group"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <LayoutGrid className="w-4 h-4 text-zinc-500 group-hover:text-brand-light transition-colors shrink-0" aria-hidden="true" />
+                  <span className="text-sm font-medium text-zinc-200 truncate">{p.name}</span>
+                </div>
+                <span className="text-xs text-zinc-600 shrink-0">
+                  Updated {formatRelative(p.updatedAt)}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function formatRelative(iso: string): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  const now = Date.now()
+  const diffMs = now - then
+  const min = 60_000
+  const hr = 60 * min
+  const day = 24 * hr
+  if (diffMs < min) return 'just now'
+  if (diffMs < hr) return `${Math.round(diffMs / min)}m ago`
+  if (diffMs < day) return `${Math.round(diffMs / hr)}h ago`
+  if (diffMs < 30 * day) return `${Math.round(diffMs / day)}d ago`
+  return new Date(iso).toLocaleDateString()
+}

--- a/src/renderer/utils/planColors.ts
+++ b/src/renderer/utils/planColors.ts
@@ -1,0 +1,111 @@
+import type { PlanColor } from '../../shared/types'
+
+export const PLAN_COLOR_PALETTE: PlanColor[] = [
+  'amber',
+  'yellow',
+  'green',
+  'blue',
+  'purple',
+  'pink',
+  'orange',
+  'red',
+  'teal',
+  'indigo',
+  'gray',
+]
+
+interface ColorTheme {
+  /** Solid swatch dot */
+  swatch: string
+  /** Chip background + text color (used in cells) */
+  chip: string
+  /** Picker tile bg when selected */
+  selectedRing: string
+}
+
+export const PLAN_COLOR_THEMES: Record<PlanColor, ColorTheme> = {
+  amber:   { swatch: 'bg-amber-400',   chip: 'bg-amber-500/20 text-amber-200 border-amber-500/30 hover:bg-amber-500/30',   selectedRing: 'ring-amber-400' },
+  yellow:  { swatch: 'bg-yellow-300',  chip: 'bg-yellow-500/20 text-yellow-200 border-yellow-500/30 hover:bg-yellow-500/30', selectedRing: 'ring-yellow-300' },
+  green:   { swatch: 'bg-green-400',   chip: 'bg-green-500/20 text-green-200 border-green-500/30 hover:bg-green-500/30',   selectedRing: 'ring-green-400' },
+  blue:    { swatch: 'bg-sky-400',     chip: 'bg-sky-500/20 text-sky-200 border-sky-500/30 hover:bg-sky-500/30',           selectedRing: 'ring-sky-400' },
+  purple:  { swatch: 'bg-purple-400',  chip: 'bg-purple-500/20 text-purple-200 border-purple-500/30 hover:bg-purple-500/30', selectedRing: 'ring-purple-400' },
+  pink:    { swatch: 'bg-pink-400',    chip: 'bg-pink-500/20 text-pink-200 border-pink-500/30 hover:bg-pink-500/30',       selectedRing: 'ring-pink-400' },
+  orange:  { swatch: 'bg-orange-400',  chip: 'bg-orange-500/20 text-orange-200 border-orange-500/30 hover:bg-orange-500/30', selectedRing: 'ring-orange-400' },
+  red:     { swatch: 'bg-red-400',     chip: 'bg-red-500/20 text-red-200 border-red-500/30 hover:bg-red-500/30',           selectedRing: 'ring-red-400' },
+  teal:    { swatch: 'bg-teal-400',    chip: 'bg-teal-500/20 text-teal-200 border-teal-500/30 hover:bg-teal-500/30',       selectedRing: 'ring-teal-400' },
+  indigo:  { swatch: 'bg-indigo-400',  chip: 'bg-indigo-500/20 text-indigo-200 border-indigo-500/30 hover:bg-indigo-500/30', selectedRing: 'ring-indigo-400' },
+  gray:    { swatch: 'bg-zinc-500',    chip: 'bg-zinc-500/20 text-zinc-200 border-zinc-500/30 hover:bg-zinc-500/30',       selectedRing: 'ring-zinc-400' },
+}
+
+/** Pick the next color from the palette that isn't already used by another project. */
+export function nextUnusedColor(usedColors: PlanColor[]): PlanColor {
+  for (const c of PLAN_COLOR_PALETTE) {
+    if (!usedColors.includes(c)) return c
+  }
+  return PLAN_COLOR_PALETTE[usedColors.length % PLAN_COLOR_PALETTE.length]
+}
+
+/**
+ * Generate two consecutive Mon-Fri week labels starting at the Monday on or after
+ * the given anchor date. Used as default labels for new iterations (which have 2 cols).
+ */
+export function defaultIterationColumnLabels(anchor: Date = new Date(), count = 2): string[] {
+  const labels: string[] = []
+  // advance to next Monday on or after anchor
+  const d = new Date(anchor)
+  d.setHours(0, 0, 0, 0)
+  const day = d.getDay() // 0 = Sun, 1 = Mon
+  const diff = (8 - day) % 7 // next Monday (or today if already Mon)
+  d.setDate(d.getDate() + diff)
+
+  for (let i = 0; i < count; i++) {
+    const start = new Date(d)
+    const end = new Date(d)
+    end.setDate(end.getDate() + 4) // Mon-Fri
+    labels.push(formatRange(start, end))
+    d.setDate(d.getDate() + 7)
+  }
+  return labels
+}
+
+function formatRange(start: Date, end: Date): string {
+  const sMonth = start.toLocaleString('en-US', { month: 'short' })
+  const eMonth = end.toLocaleString('en-US', { month: 'short' })
+  if (sMonth === eMonth) {
+    return `${sMonth} ${start.getDate()}-${end.getDate()}`
+  }
+  return `${sMonth} ${start.getDate()}-${eMonth} ${end.getDate()}`
+}
+
+/** After the latest column in a plan, what should the next iteration's labels be? */
+export function nextIterationLabels(allLabels: string[], count = 2): string[] {
+  // Try to parse the last label and continue from it; otherwise default to "today".
+  const last = allLabels[allLabels.length - 1]
+  if (last) {
+    const parsed = parseLabelEnd(last)
+    if (parsed) {
+      const anchor = new Date(parsed)
+      anchor.setDate(anchor.getDate() + 3) // skip weekend → next Monday
+      return defaultIterationColumnLabels(anchor, count)
+    }
+  }
+  return defaultIterationColumnLabels(new Date(), count)
+}
+
+function parseLabelEnd(label: string): Date | null {
+  // Match e.g. "Jan 5-9" → end "Jan 9"; "Jan 30-Feb 3" → end "Feb 3"
+  const m = label.match(/([A-Za-z]+)\s+\d+\s*-\s*(?:([A-Za-z]+)\s+)?(\d+)/)
+  if (!m) return null
+  const startMonth = m[1]
+  const endMonth = m[2] || startMonth
+  const endDay = parseInt(m[3], 10)
+  const monthIdx = MONTHS.indexOf(endMonth)
+  if (monthIdx < 0 || isNaN(endDay)) return null
+  const now = new Date()
+  let year = now.getFullYear()
+  // If the parsed month is much earlier than current, assume next year
+  if (monthIdx < now.getMonth() - 6) year += 1
+  return new Date(year, monthIdx, endDay)
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -390,6 +390,69 @@ export interface TeamDetectionResult {
 }
 
 // ── IPC channel types ──
+export type PlanColor =
+  | 'amber'
+  | 'yellow'
+  | 'green'
+  | 'blue'
+  | 'purple'
+  | 'pink'
+  | 'gray'
+  | 'orange'
+  | 'red'
+  | 'teal'
+  | 'indigo'
+
+export interface PlanColumn {
+  id: string
+  label: string
+}
+
+export interface PlanIteration {
+  id: string
+  name?: string
+  columns: PlanColumn[]
+}
+
+export interface PlanPerson {
+  id: string
+  name: string
+  reportSlug?: string
+  github?: string
+}
+
+export interface PlanProject {
+  id: string
+  name: string
+  color: PlanColor
+  driPersonId?: string
+  estWeeks: number | null
+  url?: string
+}
+
+export interface PlanAssignment {
+  personId: string
+  columnId: string
+  projectId: string
+}
+
+export interface Plan {
+  slug: string
+  name: string
+  iterations: PlanIteration[]
+  people: PlanPerson[]
+  projects: PlanProject[]
+  assignments: PlanAssignment[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PlanSummary {
+  slug: string
+  name: string
+  updatedAt: string
+}
+
 export interface IpcApi {
   // Auth
   getAuthStatus: () => Promise<{ authenticated: boolean; user?: string }>
@@ -486,4 +549,11 @@ export interface IpcApi {
   onFindToggle: (cb: () => void) => () => void
   onFindNext: (cb: () => void) => () => void
   onFindPrev: (cb: () => void) => () => void
+
+  // Plans
+  listPlans: () => Promise<PlanSummary[]>
+  getPlan: (slug: string) => Promise<Plan | null>
+  createPlan: (name: string) => Promise<Plan>
+  savePlan: (plan: Plan) => Promise<void>
+  deletePlan: (slug: string) => Promise<void>
 }

--- a/tests/main/plans.test.ts
+++ b/tests/main/plans.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let _testRepoPath = ''
+
+vi.mock('../../src/main/store', () => ({
+  getSettings: () => ({
+    repoPath: _testRepoPath,
+    repoOwner: '',
+    repoName: '',
+    githubToken: 'fake',
+    defaultModel: 'gpt-4.1',
+    aiCustomInstructions: '',
+    userName: 'Mike Crittenden',
+    userGithub: '',
+  }),
+  setToken: vi.fn(),
+  getToken: () => 'fake-token',
+  saveSettings: vi.fn(),
+  getSettingsForRenderer: vi.fn(),
+}))
+
+import { listPlans, getPlan, createPlan, savePlan, deletePlan, __test } from '../../src/main/plans'
+import { clearAllCaches } from '../../src/main/github'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'plans-test-'))
+  _testRepoPath = tmpDir
+  clearAllCaches()
+})
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+})
+
+describe('plans storage', () => {
+  it('createPlan writes to plans/<slug>.json with normalized fields', async () => {
+    const plan = await createPlan('FY26 Roadmap')
+    expect(plan.slug).toBe('fy26-roadmap')
+    expect(plan.iterations).toEqual([])
+    expect(plan.people).toEqual([])
+    expect(plan.projects).toEqual([])
+    expect(plan.assignments).toEqual([])
+    expect(existsSync(join(tmpDir, 'plans', 'fy26-roadmap.json'))).toBe(true)
+  })
+
+  it('createPlan disambiguates slugs when name collides', async () => {
+    const a = await createPlan('My Plan')
+    const b = await createPlan('My Plan')
+    expect(a.slug).toBe('my-plan')
+    expect(b.slug).toBe('my-plan-2')
+  })
+
+  it('createPlan with empty name uses fallback', async () => {
+    const p = await createPlan('   ')
+    expect(p.name).toBe('Untitled plan')
+    expect(p.slug).toBe('untitled-plan')
+  })
+
+  it('getPlan returns null for missing plan', async () => {
+    expect(await getPlan('nope')).toBeNull()
+  })
+
+  it('listPlans returns summaries sorted by updatedAt desc', async () => {
+    const a = await createPlan('Alpha')
+    await new Promise(r => setTimeout(r, 10))
+    const b = await createPlan('Beta')
+    const list = listPlans()
+    expect(list.map(p => p.slug)).toEqual([b.slug, a.slug])
+  })
+
+  it('savePlan persists changes and updates updatedAt', async () => {
+    const p = await createPlan('Plan X')
+    const before = p.updatedAt
+    await new Promise(r => setTimeout(r, 5))
+    await savePlan({
+      ...p,
+      iterations: [{ id: 'it1', columns: [{ id: 'c1', label: 'Wk 1' }] }],
+      people: [{ id: 'pe1', name: 'Steve' }],
+      projects: [{ id: 'pr1', name: 'Foo', color: 'amber', estWeeks: 3 }],
+      assignments: [{ personId: 'pe1', columnId: 'c1', projectId: 'pr1' }],
+    })
+    const reloaded = await getPlan(p.slug)
+    expect(reloaded?.iterations).toHaveLength(1)
+    expect(reloaded?.assignments).toHaveLength(1)
+    expect(reloaded?.updatedAt > before).toBe(true)
+  })
+
+  it('savePlan strips assignments referencing nonexistent ids', async () => {
+    const p = await createPlan('Cleanup')
+    await savePlan({
+      ...p,
+      iterations: [{ id: 'it1', columns: [{ id: 'c1', label: 'Wk 1' }] }],
+      people: [{ id: 'pe1', name: 'Steve' }],
+      projects: [{ id: 'pr1', name: 'Foo', color: 'amber', estWeeks: 1 }],
+      assignments: [
+        { personId: 'pe1', columnId: 'c1', projectId: 'pr1' }, // valid
+        { personId: 'pe1', columnId: 'GONE', projectId: 'pr1' }, // bad column
+        { personId: 'GONE', columnId: 'c1', projectId: 'pr1' }, // bad person
+        { personId: 'pe1', columnId: 'c1', projectId: 'GONE' }, // bad project
+      ],
+    })
+    const reloaded = await getPlan(p.slug)
+    expect(reloaded?.assignments).toEqual([
+      { personId: 'pe1', columnId: 'c1', projectId: 'pr1' },
+    ])
+  })
+
+  it('deletePlan removes the file', async () => {
+    const p = await createPlan('Doomed')
+    expect(existsSync(join(tmpDir, 'plans', `${p.slug}.json`))).toBe(true)
+    await deletePlan(p.slug)
+    expect(existsSync(join(tmpDir, 'plans', `${p.slug}.json`))).toBe(false)
+    expect(await getPlan(p.slug)).toBeNull()
+  })
+
+  it('deletePlan no-ops for missing plan', async () => {
+    await expect(deletePlan('nope')).resolves.toBeUndefined()
+  })
+
+  it('savePlan throws if slug is missing', async () => {
+    await expect(savePlan({
+      slug: '',
+      name: 'x',
+      iterations: [], people: [], projects: [], assignments: [],
+      createdAt: '', updatedAt: '',
+    })).rejects.toThrow(/slug/i)
+  })
+
+  it('getPlan tolerates malformed JSON by returning null', async () => {
+    mkdirSync(join(tmpDir, 'plans'), { recursive: true })
+    writeFileSync(join(tmpDir, 'plans', 'bad.json'), '{not json')
+    expect(await getPlan('bad')).toBeNull()
+  })
+
+  it('getPlan tolerates plans missing array fields', async () => {
+    mkdirSync(join(tmpDir, 'plans'), { recursive: true })
+    writeFileSync(join(tmpDir, 'plans', 'partial.json'), JSON.stringify({
+      slug: 'partial',
+      name: 'Partial',
+      createdAt: '',
+      updatedAt: '',
+    }))
+    const p = await getPlan('partial')
+    expect(p?.iterations).toEqual([])
+    expect(p?.people).toEqual([])
+    expect(p?.projects).toEqual([])
+    expect(p?.assignments).toEqual([])
+  })
+
+  it('slugify produces ASCII-only kebab slugs', () => {
+    expect(__test.slugify('My Plan!')).toBe('my-plan')
+    expect(__test.slugify('  Hello   World  ')).toBe('hello-world')
+    expect(__test.slugify('Cafe (FY26)')).toBe('cafe-fy26')
+  })
+})

--- a/tests/renderer/PlanDetail.test.tsx
+++ b/tests/renderer/PlanDetail.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ReactDOM from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PlanDetail } from '../../src/renderer/pages/PlanDetail'
+import { ToastProvider } from '../../src/renderer/components/common/Toast'
+import { TeamOverviewProvider } from '../../src/renderer/hooks/useData'
+import type { Plan } from '../../src/shared/types'
+
+const samplePlan = (overrides: Partial<Plan> = {}): Plan => ({
+  slug: 'fy26',
+  name: 'FY26 Plan',
+  iterations: [],
+  people: [],
+  projects: [],
+  assignments: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+})
+
+let lastSavedPlan: Plan | null = null
+
+async function render(slug = 'fy26') {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[`/plans/${slug}`]}>
+        <ToastProvider>
+          <TeamOverviewProvider>
+            <Routes>
+              <Route path="/plans/:slug" element={<PlanDetail />} />
+              <Route path="/plans" element={<div data-testid="list-route" />} />
+            </Routes>
+          </TeamOverviewProvider>
+        </ToastProvider>
+      </MemoryRouter>
+    )
+  })
+  // Allow load + render passes to flush
+  for (let i = 0; i < 5; i++) {
+    await act(async () => { await Promise.resolve() })
+  }
+  return { container, root }
+}
+
+describe('PlanDetail page', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true,
+      value: true,
+      writable: true,
+    })
+    document.body.innerHTML = ''
+    lastSavedPlan = null
+  })
+
+  function installApi(plan: Plan | null, save?: (p: Plan) => Promise<void>) {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        getPlan: vi.fn().mockResolvedValue(plan),
+        savePlan: vi.fn(async (p: Plan) => {
+          lastSavedPlan = p
+          if (save) await save(p)
+        }),
+        deletePlan: vi.fn().mockResolvedValue(undefined),
+        getTeamOverview: vi.fn().mockResolvedValue({ reports: [] }),
+      },
+    })
+  }
+
+  it('renders not-found message when plan is missing', async () => {
+    installApi(null)
+    const { container } = await render('missing')
+    expect(container.textContent).toContain('Plan not found')
+  })
+
+  it('renders plan name and empty grid prompts', async () => {
+    installApi(samplePlan({ name: 'My Roadmap' }))
+    const { container } = await render()
+    const titleInput = container.querySelector('input[type="text"]') as HTMLInputElement
+    expect(titleInput.value).toBe('My Roadmap')
+    expect(container.textContent).toContain('No iterations yet')
+    expect(container.textContent).toContain('No people on this plan yet')
+  })
+
+  it('adds an iteration with two default columns', async () => {
+    vi.useFakeTimers()
+    installApi(samplePlan())
+    const { container } = await render()
+    const addItBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent?.includes('+ Iteration'))!
+    await act(async () => { addItBtn.click() })
+    // Drain debounced save (600ms)
+    await act(async () => { await vi.advanceTimersByTimeAsync(700) })
+    expect(lastSavedPlan?.iterations).toHaveLength(1)
+    expect(lastSavedPlan?.iterations[0].columns).toHaveLength(2)
+    vi.useRealTimers()
+  })
+
+  it('adds a project with auto-assigned color and counts planned/estimated', async () => {
+    vi.useFakeTimers()
+    installApi(samplePlan({
+      iterations: [{ id: 'it1', columns: [{ id: 'c1', label: 'W1' }, { id: 'c2', label: 'W2' }] }],
+      people: [{ id: 'pe1', name: 'Steve' }],
+    }))
+    const { container } = await render()
+    const addProjBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === '+ Add project')!
+    await act(async () => { addProjBtn.click() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(700) })
+    expect(lastSavedPlan?.projects).toHaveLength(1)
+    expect(lastSavedPlan?.projects[0].color).toBe('amber')
+    vi.useRealTimers()
+  })
+
+  it('counts planned weeks correctly per project', async () => {
+    installApi(samplePlan({
+      iterations: [{ id: 'it1', columns: [{ id: 'c1', label: 'W1' }, { id: 'c2', label: 'W2' }] }],
+      people: [{ id: 'pe1', name: 'Steve' }],
+      projects: [{ id: 'pr1', name: 'Foo', color: 'amber', estWeeks: 4 }],
+      assignments: [
+        { personId: 'pe1', columnId: 'c1', projectId: 'pr1' },
+        { personId: 'pe1', columnId: 'c2', projectId: 'pr1' },
+      ],
+    }))
+    const { container } = await render()
+    expect(container.textContent).toContain('2 / 4 wk')
+  })
+})

--- a/tests/renderer/Plans.test.tsx
+++ b/tests/renderer/Plans.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import ReactDOM from 'react-dom/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Plans } from '../../src/renderer/pages/Plans'
+import { ToastProvider } from '../../src/renderer/components/common/Toast'
+
+async function renderPlans() {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = ReactDOM.createRoot(container)
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={['/plans']}>
+        <ToastProvider>
+          <Routes>
+            <Route path="/plans" element={<Plans />} />
+            <Route path="/plans/:slug" element={<div data-testid="detail-route" />} />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>
+    )
+  })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  return { container, root }
+}
+
+describe('Plans page', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true,
+      value: true,
+      writable: true,
+    })
+    document.body.innerHTML = ''
+  })
+
+  it('shows empty state when no plans exist', async () => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { listPlans: vi.fn().mockResolvedValue([]) },
+    })
+    const { container } = await renderPlans()
+    expect(container.textContent).toContain('No plans yet')
+  })
+
+  it('shows existing plans sorted from API response', async () => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        listPlans: vi.fn().mockResolvedValue([
+          { slug: 'fy26', name: 'FY26 Roadmap', updatedAt: new Date().toISOString() },
+          { slug: 'q1', name: 'Q1 Goals', updatedAt: new Date().toISOString() },
+        ]),
+      },
+    })
+    const { container } = await renderPlans()
+    expect(container.textContent).toContain('FY26 Roadmap')
+    expect(container.textContent).toContain('Q1 Goals')
+  })
+
+  it('creates a new plan via the inline form and navigates to detail', async () => {
+    const create = vi.fn().mockResolvedValue({
+      slug: 'my-plan',
+      name: 'My Plan',
+      iterations: [], people: [], projects: [], assignments: [],
+      createdAt: '', updatedAt: '',
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        listPlans: vi.fn().mockResolvedValue([]),
+        createPlan: create,
+      },
+    })
+    const { container } = await renderPlans()
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!
+      setter.call(input, 'My Plan')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await Promise.resolve() })
+    expect(create).toHaveBeenCalledWith('My Plan')
+    expect(document.querySelector('[data-testid="detail-route"]')).toBeTruthy()
+  })
+
+  it('uses fallback name when input is empty', async () => {
+    const create = vi.fn().mockResolvedValue({
+      slug: 'untitled-plan',
+      name: 'Untitled plan',
+      iterations: [], people: [], projects: [], assignments: [],
+      createdAt: '', updatedAt: '',
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { listPlans: vi.fn().mockResolvedValue([]), createPlan: create },
+    })
+    const { container } = await renderPlans()
+    const form = container.querySelector('form')!
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+    await act(async () => { await Promise.resolve() })
+    expect(create).toHaveBeenCalledWith('Untitled plan')
+  })
+})

--- a/tests/renderer/planColors.test.ts
+++ b/tests/renderer/planColors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { defaultIterationColumnLabels, nextIterationLabels, nextUnusedColor, PLAN_COLOR_PALETTE } from '../../src/renderer/utils/planColors'
+
+describe('planColors', () => {
+  describe('nextUnusedColor', () => {
+    it('returns first palette color when nothing is used', () => {
+      expect(nextUnusedColor([])).toBe(PLAN_COLOR_PALETTE[0])
+    })
+    it('skips already-used colors', () => {
+      expect(nextUnusedColor(['amber', 'yellow'])).toBe('green')
+    })
+    it('wraps around when palette is exhausted', () => {
+      const result = nextUnusedColor([...PLAN_COLOR_PALETTE])
+      expect(PLAN_COLOR_PALETTE).toContain(result)
+    })
+  })
+
+  describe('defaultIterationColumnLabels', () => {
+    it('returns the requested number of labels', () => {
+      expect(defaultIterationColumnLabels(new Date('2026-01-01'), 3)).toHaveLength(3)
+    })
+    it('produces Mon-Fri ranges starting on the next Monday', () => {
+      // Jan 1 2026 is a Thursday → next Mon is Jan 5
+      const labels = defaultIterationColumnLabels(new Date('2026-01-01'), 2)
+      expect(labels[0]).toBe('Jan 5-9')
+      expect(labels[1]).toBe('Jan 12-16')
+    })
+    it('handles month boundary in a single label', () => {
+      // Jan 26 2026 is a Monday → Jan 26-30, then Feb 2-6
+      const labels = defaultIterationColumnLabels(new Date('2026-01-26'), 2)
+      expect(labels[0]).toBe('Jan 26-30')
+      expect(labels[1]).toBe('Feb 2-6')
+    })
+  })
+
+  describe('nextIterationLabels', () => {
+    it('continues from the end of the previous iteration', () => {
+      const labels = nextIterationLabels(['Jan 5-9', 'Jan 12-16'], 2)
+      // After Jan 16 (Fri), advance 3d → Jan 19 (Mon)
+      expect(labels[0]).toBe('Jan 19-23')
+      expect(labels[1]).toBe('Jan 26-30')
+    })
+    it('falls back to today if no previous labels', () => {
+      const labels = nextIterationLabels([], 2)
+      expect(labels).toHaveLength(2)
+      expect(labels[0]).toMatch(/^[A-Z][a-z]+ \d+-/)
+    })
+  })
+})


### PR DESCRIPTION
Closes nothing yet — new feature.

Adds a new **Plans** sidebar entry (⌘4) for building per-team capacity plans, similar to a Gantt or project-tracking board.

## What it does

- **Top grid**: rows = people on the plan, columns grouped under "iterations" (each iteration is a 1+-week block). Cells hold one or more colored project chips.
- **Bottom table**: projects with editable color, name, DRI dropdown (people in plan), est. weeks, URL (e.g. GitHub issue), and an auto-calculated `planned / estimated wk` counter (emerald when matched, amber when over).
- **Two assignment modes**:
  1. Click any cell → popover lets you pick projects to add/remove
  2. Drag a project chip from the projects table onto a cell
- **Adding a person** shows a dialog of your direct reports (those not already on the plan), plus a custom-name option for cross-team partners.
- **Adding an iteration** auto-generates two consecutive Mon-Fri week labels (e.g. "Jan 5-9", "Jan 12-16"), continuing from the latest existing column. All labels are inline-editable.
- **Multiple plans** supported. `/plans` lists them; click to drill in. Each plan also has a delete button.
- **Autosave** with 600 ms debounce and an inline "Saving / Saved" indicator.

## Storage

Each plan is one JSON file at `plans/<slug>.json` in the data repo, so plans are git-versioned and pushed via the normal commit flow. Orphaned assignments are stripped automatically on save.

## Files

- `src/main/plans.ts` — storage layer (CRUD)
- `src/main/ipc.ts`, `src/preload/index.ts`, `src/shared/types.ts` — IPC + types
- `src/renderer/pages/Plans.tsx` — list page
- `src/renderer/pages/PlanDetail.tsx` — main editor page
- `src/renderer/components/plan/PlanGrid.tsx` — the gantt-style grid
- `src/renderer/components/plan/ProjectsTable.tsx` — projects with DRI / est / planned / URL
- `src/renderer/components/plan/AssignCellPopover.tsx` — cell click → assign
- `src/renderer/components/plan/ColorSwatchPicker.tsx` — color palette popover
- `src/renderer/utils/planColors.ts` — color palette + week-label generator
- `src/renderer/components/layout/AppShell.tsx` — sidebar entry, ⌘1-6 shortcuts

## Tests

30 new tests, all green:
- `tests/main/plans.test.ts` (13) — storage CRUD, slug uniqueness, orphaned-assignment cleanup
- `tests/renderer/planColors.test.ts` (8) — palette + Mon-Fri label generator
- `tests/renderer/Plans.test.tsx` (4) — list + create flow
- `tests/renderer/PlanDetail.test.tsx` (5) — load, render, add iteration / project, planned counter

Full suite: **1046 passed**.