### PR TITLE
Fix meeting attendee parsing: separate attendees from mentions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,46 @@
 # AGENTS.md — Session Context for AI Agents
 
+## Recent Changes (May 2026)
+
+### Meeting attendees: distinguish actual participants from people merely mentioned (COMPLETE)
+The classify-content AI flow used to dump every name from `people_mentioned` into the `speakers:` frontmatter of captured meetings. Because `getRelevantSlugs` in `github.ts` uses `speakers:` as the authoritative attendance list, this caused meetings to be linked to reports who were only discussed (not present). It also made `isOneOnOneWith` in `syncToReport.ts` reject legitimate 1:1s whenever the manager mentioned a third party by name.
+
+**The split**
+- The `classify-content` prompt (both `src/main/copilot.ts` and the display copy in `src/shared/prompts.ts`) now requests two distinct JSON fields:
+  - `attendees: ["Exact Name"]` — meeting participants only. Empty for non-meeting sources.
+  - `people_mentioned: ["Exact Name"]` — anyone meaningfully discussed, regardless of presence.
+- The over-inclusive "ALWAYS include every attendee/participant of the meeting in this list, even if they only listened" line is gone. The new rules explicitly call out that a person can appear in one, the other, or both.
+
+**Deterministic transcript speaker extraction**
+- New pure helper in `src/renderer/utils/transcriptCleaners.ts`: `extractSpeakersFromCleanedTranscript(content)`. Scans `**Name:**` and `**Name**:` prefixes anchored to the start of a line (with optional list-marker prefixes like `- **Name:**`), dedupes case-insensitively while preserving first-seen casing, and filters out a small blocklist of section labels (`Summary`, `Attendees`, `Action items`, `Feedback`, `Notes`, `Context`, `Raw content`, `Type`, `Source`, `Date`, `Title`, `Tags`, `Overview`, `Agenda`, `Next steps`, `Decisions`, `Topic(s)`, `PR`, `Issue`, `Link`, `TL;DR`).
+- Tokens that don't look like a person name (1–4 capitalized-ish tokens) are also rejected. This protects against bolded sentences like `**This Is A Very Long Sentence That Was Bolded:**` being treated as a speaker.
+
+**`buildMeetingAttendees` contract change**
+- `src/renderer/utils/captureAttendees.ts#buildMeetingAttendees(currentUserName, attendees)` now takes an *explicit attendee list*, not `people_mentioned`. The JSDoc explicitly warns: *do not pass `people_mentioned` — that conflates mentioned-only people with actual attendees.*
+- `shouldRecordAttendees` is unchanged.
+
+**Capture wiring (`CaptureSession.tsx`)**
+- `ClassifiedResult` gains optional `attendees?: string[]` (defaults to `[]` after JSON parse, even if the AI omits it).
+- For meeting captures, `speakers:` is now built as:
+  ```
+  currentUser ∪ extractSpeakersFromCleanedTranscript(initialContent) ∪ ai.attendees
+  ```
+  Names are deduped case-insensitively. `people_mentioned` is **never** used for `speakers:`.
+- `people:` continues to be derived from `people_mentioned` (slugified). A meeting that discussed Tara without her presence still appears under `people: [tara]` so PersonDetail can surface it, but `speakers: [Mike, Steve]` keeps it out of Tara's `ReportDetail` stream.
+- If neither the deterministic extractor nor the AI yields any attendees, `speakers:` is omitted entirely (not faked up with just the current user). `getRelevantSlugs` then falls back to `people:`, matching the prior safe default for that edge case.
+
+**No migration for existing files (by choice)**
+- Existing capture files that already have over-inclusive `speakers:` continue to parse as-is. Users can edit them via the existing Attendees UI in `ContextDetail`. We didn't write a one-time rewriter because re-deriving attendees from already-summarized content would itself rely on AI heuristics.
+
+**Sync impact (positive side effect)**
+- This strictly tightens `speakers:`, so `isOneOnOneWith` in `syncToReport.ts` becomes more accurate going forward — 1:1s that were previously rejected because a third party was mentioned will now sync correctly when re-captured.
+
+**Tests**
+- `tests/renderer/captureAttendees.test.ts` — migrated to the new explicit-attendees contract.
+- `tests/renderer/transcriptCleaners.test.ts` — 9 new tests for `extractSpeakersFromCleanedTranscript` covering single/multiple speakers, both bold-colon forms, list markers, blocklist filtering, dedup, mid-paragraph false positives, and non-name rejection.
+- `tests/main/copilot.test.ts` — extended `classify-content` `buildMessages` coverage to assert the new `attendees` field is documented and the old over-inclusive sentence is gone.
+- `tests/renderer/captureAttendeesIntegration.test.tsx` (new, 5 tests) — mounts `CaptureSession` with stubbed AI responses and inspects the resulting `commitFile` payload to verify: `people_mentioned` never leaks into `speakers:`; AI `attendees` drives `speakers:` when present; deterministic transcript `**Name:**` extraction works when the AI returns empty; union/dedup behavior; non-meeting sources omit `speakers:`.
+
 ## Recent Changes (April 2026)
 
 ### Per-direct-report repo sync + transcript cleanup (COMPLETE)

--- a/src/main/copilot.ts
+++ b/src/main/copilot.ts
@@ -595,6 +595,7 @@ Required JSON shape:
   "detailed_summary": "A thorough markdown summary. For meetings: key topics discussed, decisions made, wins, challenges, sentiment. For Slack/email: main thread of discussion, conclusions reached, open questions. Use bullet points and short paragraphs. This should be useful months later when reviewing what happened.",
   "tags": ["relevant", "tags"],
   "people_mentioned": ["Exact Name"],
+  "attendees": ["Exact Name"],
   "feedback": [
     {
       "person": "Exact Name",
@@ -624,7 +625,9 @@ Required JSON shape:
 }
 
 Rules:
-- "people_mentioned" should only include people who are meaningfully discussed, not just @mentioned in passing
+- "people_mentioned" is anyone meaningfully discussed in the content, regardless of whether they were present. For meetings, this includes people who are talked about but didn't attend. Skip mere passing @mentions with no substance.
+- "attendees" is ONLY for meetings: the actual participants who were present. Identify them from speaker turns, greetings ("Hi Alex"), sign-offs, transcript voice labels, or an explicit attendees list. Do NOT include people who were only discussed. For non-meeting sources (slack, github, email, feedback, other), use an empty array.
+- A person can appear in BOTH attendees and people_mentioned (an attendee discussed during the meeting). A person can also appear in only one (a quiet attendee → attendees only; a topic of conversation who wasn't present → people_mentioned only).
 - "feedback" should only contain concrete, behavior-anchored observations about my direct reports
 - For "person" fields, use the exact name from my reports list when possible
 - If no feedback, action items, or impact exist, use empty arrays

--- a/src/renderer/components/common/CaptureSession.tsx
+++ b/src/renderer/components/common/CaptureSession.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAI } from '../../hooks/useAI'
 import { useSettings } from '../../hooks/useData'
 import { buildMeetingAttendees, shouldRecordAttendees } from '../../utils/captureAttendees'
+import { extractSpeakersFromCleanedTranscript } from '../../utils/transcriptCleaners'
 import { useToast } from './Toast'
 import { format } from 'date-fns'
 import { IMPACT_LOG_PATH } from '../../../shared/constants'
@@ -26,6 +27,7 @@ interface ClassifiedResult {
   detailed_summary: string
   tags: string[]
   people_mentioned: string[]
+  attendees?: string[]
   feedback: { person: string; type: 'positive' | 'constructive' | 'mixed'; content: string }[]
   action_items: { text: string; owner: string }[]
   resolved_action_items: { original_text: string; owner: string; reason: string }[]
@@ -113,11 +115,25 @@ export function CaptureSession({
       ? `people:\n${peopleSlugs.map(s => `  - ${s}`).join('\n')}`
       : 'people: []'
 
-    // For meeting captures, always record attendees (current user + people meaningfully discussed)
-    // so the meeting shows up under the right person and speakers render correctly.
+    // For meeting captures, build the `speakers:` frontmatter from ACTUAL
+    // attendees only — never from `people_mentioned` (which includes people
+    // who were merely discussed). Sources, in order of trust:
+    //   1. Deterministic `**Name:**` prefixes in the cleaned content (always
+    //      present for VTT/SRT transcripts after `cleanTranscript`).
+    //   2. The AI's separate `attendees` field from `classify-content`.
+    //   3. The current user (manager) — always added when known.
+    // When none of these sources yield any attendees, omit `speakers:` rather
+    // than fabricate one. `getRelevantSlugs` will then fall back to `people:`,
+    // matching prior behavior for that edge case.
     let speakersYaml = ''
     if (shouldRecordAttendees(classified.source, sourceHint)) {
-      const attendees = buildMeetingAttendees(settings?.userName, classified.people_mentioned)
+      const deterministic = extractSpeakersFromCleanedTranscript(initialContent)
+      const aiAttendees = Array.isArray(classified.attendees) ? classified.attendees : []
+      const union = [...deterministic, ...aiAttendees]
+      const haveAnyAttendee = union.length > 0
+      const attendees = haveAnyAttendee
+        ? buildMeetingAttendees(settings?.userName, union)
+        : []
       if (attendees.length > 0) {
         speakersYaml = `speakers:\n${attendees.map(n => `  - ${n}`).join('\n')}\n`
       }
@@ -302,6 +318,9 @@ export function CaptureSession({
           parsed = JSON.parse(jsonStr)
           if (!parsed.resolved_action_items) {
             parsed.resolved_action_items = []
+          }
+          if (!Array.isArray(parsed.attendees)) {
+            parsed.attendees = []
           }
         } catch (e) {
           console.error('Failed to parse AI classification JSON:', e)

--- a/src/renderer/utils/captureAttendees.ts
+++ b/src/renderer/utils/captureAttendees.ts
@@ -2,14 +2,24 @@
  * Build the deduplicated list of attendees for a captured meeting.
  *
  * The current user (manager) is always included first when known, then any
- * people the AI extracted as meaningfully discussed. Names are compared
- * case-insensitively for de-duplication; the original casing is preserved.
+ * names supplied as the actual attendees of the meeting (NOT
+ * `people_mentioned` — those are people discussed, not necessarily present).
+ * Names are compared case-insensitively for dedup; the first-seen casing is
+ * preserved.
+ *
+ * Callers typically construct the `attendees` argument as the union of:
+ *   - deterministic speakers parsed from the transcript content
+ *   - the AI's `attendees` field from `classify-content`
+ *
+ * `people_mentioned` MUST NOT be passed in here. Passing mentioned-only people
+ * causes them to be incorrectly listed as meeting speakers, which then
+ * associates the meeting with their report stream in the UI.
  */
 export function buildMeetingAttendees(
   currentUserName: string | undefined | null,
-  peopleMentioned: string[] | undefined | null,
+  attendees: string[] | undefined | null,
 ): string[] {
-  const attendees: string[] = []
+  const out: string[] = []
   const seen = new Set<string>()
   const add = (raw: string) => {
     const name = (raw || '').trim()
@@ -17,13 +27,13 @@ export function buildMeetingAttendees(
     const key = name.toLowerCase()
     if (seen.has(key)) return
     seen.add(key)
-    attendees.push(name)
+    out.push(name)
   }
 
   if (currentUserName) add(currentUserName)
-  for (const p of peopleMentioned || []) add(p)
+  for (const p of attendees || []) add(p)
 
-  return attendees
+  return out
 }
 
 /**

--- a/src/renderer/utils/transcriptCleaners.ts
+++ b/src/renderer/utils/transcriptCleaners.ts
@@ -146,3 +146,81 @@ export function cleanTranscript(filename: string | undefined, raw: string): stri
 }
 
 export const __test = { parseVtt, parseSrt, mergeAdjacentSameSpeaker, extractSpeakerFromVoiceTag, extractInlineSpeakerPrefix }
+
+// Section/field labels that may appear in `**Label:**` form inside captured
+// markdown but are NOT speaker names. Lowercased for case-insensitive matching.
+const SPEAKER_BLOCKLIST = new Set([
+  'summary',
+  'attendees',
+  'attendee',
+  'action items',
+  'action item',
+  'feedback',
+  'notes',
+  'context',
+  'key context',
+  'raw content',
+  'type',
+  'source',
+  'date',
+  'title',
+  'tags',
+  'overview',
+  'agenda',
+  'next steps',
+  'decisions',
+  'topic',
+  'topics',
+  'pr',
+  'issue',
+  'link',
+  'tldr',
+  'tl;dr',
+  'tl dr',
+])
+
+// A plausible person name: 1-4 whitespace-separated tokens, each starting with
+// a letter and containing only letters, apostrophes, hyphens, or periods.
+const NAME_TOKEN = /^[A-Za-zÀ-ÖØ-öø-ÿ][A-Za-zÀ-ÖØ-öø-ÿ'.\-]*$/
+
+function looksLikePersonName(raw: string): boolean {
+  const name = raw.trim()
+  if (!name) return false
+  if (SPEAKER_BLOCKLIST.has(name.toLowerCase())) return false
+  const tokens = name.split(/\s+/)
+  if (tokens.length < 1 || tokens.length > 4) return false
+  return tokens.every(t => NAME_TOKEN.test(t))
+}
+
+/**
+ * Extract a deduplicated list of speakers from content that already contains
+ * `**Speaker:**` prefixes at the start of paragraphs (the format produced by
+ * `cleanTranscript` for VTT/SRT inputs, and the convention used by some
+ * meeting note tools).
+ *
+ * Recognizes both `**Name:**` and `**Name**:` forms. Skips obvious section
+ * labels via a small blocklist (Summary, Attendees, Action items, etc.) and
+ * tokens that don't look like a person name. Dedup is case-insensitive but the
+ * first-seen casing is preserved.
+ *
+ * Returns `[]` when no speaker prefixes are detected — callers can then fall
+ * back to other sources (AI attendees, manual entry, etc.).
+ */
+export function extractSpeakersFromCleanedTranscript(content: string): string[] {
+  if (!content) return []
+  // Match `**Name:**` or `**Name**:` at the start of a line. The optional
+  // leading characters allow for list markers like `- **Name:**` too.
+  const pattern = /^[\s>*\-]*\*\*([^*:\n]{1,80})(?::\*\*|\*\*\s*:)/gm
+  const seen = new Set<string>()
+  const out: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(content)) !== null) {
+    const raw = match[1].trim().replace(/\s+/g, ' ')
+    if (!looksLikePersonName(raw)) continue
+    const key = raw.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(raw)
+  }
+  return out
+}

--- a/src/shared/prompts.ts
+++ b/src/shared/prompts.ts
@@ -39,6 +39,7 @@ Required JSON shape:
   "detailed_summary": "A thorough markdown summary. For meetings: key topics discussed, decisions made, wins, challenges, sentiment. For Slack/email: main thread of discussion, conclusions reached, open questions. Use bullet points and short paragraphs. This should be useful months later when reviewing what happened.",
   "tags": ["relevant", "tags"],
   "people_mentioned": ["Exact Name"],
+  "attendees": ["Exact Name"],
   "feedback": [
     {
       "person": "Exact Name",
@@ -68,7 +69,9 @@ Required JSON shape:
 }
 
 Rules:
-- "people_mentioned" should only include people who are meaningfully discussed, not just @mentioned in passing. For meetings (especially 1:1s), ALWAYS include every attendee/participant of the meeting in this list, even if they only listened.
+- "people_mentioned" is anyone meaningfully discussed in the content, regardless of whether they were present. For meetings, this includes people who are talked about but didn't attend. Skip mere passing @mentions with no substance.
+- "attendees" is ONLY for meetings: the actual participants who were present. Identify them from speaker turns, greetings ("Hi Alex"), sign-offs, transcript voice labels, or an explicit attendees list. Do NOT include people who were only discussed. For non-meeting sources (slack, github, email, feedback, other), use an empty array.
+- A person can appear in BOTH attendees and people_mentioned (an attendee discussed during the meeting). A person can also appear in only one (a quiet attendee → attendees only; a topic of conversation who wasn't present → people_mentioned only).
 - "feedback" should only contain concrete, behavior-anchored observations about my direct reports
 - For "person" fields, use the exact name from my reports list when possible
 - If no feedback, action items, or impact exist, use empty arrays

--- a/tests/main/copilot.test.ts
+++ b/tests/main/copilot.test.ts
@@ -172,6 +172,24 @@ describe('buildMessages', () => {
     expect(userMsg.content).not.toContain('The user indicated this is from:')
   })
 
+  it('classify-content distinguishes attendees from people_mentioned', () => {
+    const result = buildMessages('classify-content', {
+      reportNames: 'Nic, Steve',
+      content: 'A meeting'
+    })
+    const userMsg = result.find(m => m.role === 'user')!
+    // Both fields are present in the JSON schema.
+    expect(userMsg.content).toContain('"people_mentioned"')
+    expect(userMsg.content).toContain('"attendees"')
+    // Attendees is explicitly described as actual participants.
+    expect(userMsg.content).toMatch(/"attendees" is ONLY for meetings/i)
+    // people_mentioned is explicitly described as discussed-not-necessarily-present.
+    expect(userMsg.content).toMatch(/regardless of whether they were present/i)
+    // The old over-inclusive sentence is gone.
+    expect(userMsg.content).not.toMatch(/ALWAYS include every attendee/i)
+    expect(userMsg.content).not.toMatch(/even if they only listened/i)
+  })
+
   it('builds summarize-team-activity messages', () => {
     const result = buildMessages('summarize-team-activity', {
       dateLabel: '2026-03-26',

--- a/tests/renderer/captureAttendees.test.ts
+++ b/tests/renderer/captureAttendees.test.ts
@@ -20,13 +20,26 @@ describe('buildMeetingAttendees', () => {
     expect(buildMeetingAttendees('  Mike  ', ['  ', '\tJennifer\n', ''])).toEqual(['Mike', 'Jennifer'])
   })
 
-  it('handles a missing people_mentioned list', () => {
+  it('handles a missing attendees list', () => {
     expect(buildMeetingAttendees('Mike', null)).toEqual(['Mike'])
     expect(buildMeetingAttendees('Mike', undefined)).toEqual(['Mike'])
   })
 
   it('returns an empty list when there are no attendees at all', () => {
     expect(buildMeetingAttendees('', [])).toEqual([])
+  })
+
+  it('accepts a unioned attendee list (deterministic transcript + AI attendees)', () => {
+    // Simulates the wiring in CaptureSession: deterministic speakers from the
+    // cleaned transcript come first, then the AI's attendees field. Dedup
+    // collapses overlaps while preserving the order the caller built.
+    const deterministic = ['Steve Richert', 'Mike']
+    const aiAttendees = ['mike', 'Tara Kintner']
+    expect(buildMeetingAttendees('Mike', [...deterministic, ...aiAttendees])).toEqual([
+      'Mike',
+      'Steve Richert',
+      'Tara Kintner',
+    ])
   })
 })
 

--- a/tests/renderer/captureAttendeesIntegration.test.tsx
+++ b/tests/renderer/captureAttendeesIntegration.test.tsx
@@ -1,0 +1,289 @@
+// @vitest-environment happy-dom
+/**
+ * Integration coverage for the meeting-attendee wiring in CaptureSession.
+ *
+ * The previous behavior dumped every name from `people_mentioned` into the
+ * `speakers:` frontmatter, causing meetings to appear under reports who were
+ * merely discussed (not present). The fix:
+ *
+ *   speakers = currentUser ∪ deterministicSpeakersFromContent ∪ ai.attendees
+ *
+ * `people_mentioned` is still used to drive the `people:` slug list, but no
+ * longer pollutes `speakers:`.
+ *
+ * These tests stub the AI to return controlled `attendees` vs `people_mentioned`
+ * payloads, mount a CaptureSession, and assert what gets passed to
+ * `window.api.commitFile` for the context file.
+ */
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ReactDOM from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() }
+vi.mock('../../src/renderer/components/common/Toast', () => ({ useToast: () => mockToast }))
+
+vi.mock('../../src/renderer/hooks/useData', () => ({
+  useSettings: () => ({ settings: { userName: 'Mike Crittenden' }, loading: false }),
+}))
+
+const generateMock = vi.fn()
+vi.mock('../../src/renderer/hooks/useAI', () => ({
+  useAI: () => ({
+    streaming: false,
+    streamedText: '',
+    generate: generateMock,
+    cancel: vi.fn(),
+    reset: vi.fn(),
+  }),
+}))
+
+const commitFileMock = vi.fn().mockResolvedValue(undefined)
+const findPersonByNameMock = vi.fn().mockImplementation(async (name: string) => {
+  // Trivial slug map for the test reports.
+  const map: Record<string, string> = {
+    'Steve Richert': 'steve',
+    'Tara Kintner': 'tara',
+    'Mike Crittenden': 'mike',
+  }
+  return map[name] ?? null
+})
+
+Object.defineProperty(window, 'api', {
+  value: {
+    commitFile: commitFileMock,
+    getFileContent: vi.fn().mockResolvedValue(''),
+    getOpenActionItemsForPeople: vi.fn().mockResolvedValue([]),
+    findPersonByName: findPersonByNameMock,
+    deleteFile: vi.fn(),
+    resolveAndToggleActionItem: vi.fn().mockResolvedValue(undefined),
+    onDataFilesChanged: undefined,
+    onAiFilesChanged: undefined,
+  },
+  writable: true,
+})
+
+import { CaptureSession } from '../../src/renderer/components/common/CaptureSession'
+
+const reports = [
+  { name: 'steve', displayName: 'Steve Richert' },
+  { name: 'tara', displayName: 'Tara Kintner' },
+]
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => <MemoryRouter>{children}</MemoryRouter>
+
+function buildClassifyResponse(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    source: 'meeting',
+    title: 'Test meeting',
+    summary: 'A test meeting',
+    detailed_summary: 'Details',
+    tags: [],
+    people_mentioned: [],
+    attendees: [],
+    feedback: [],
+    action_items: [],
+    resolved_action_items: [],
+    impact: [],
+    key_context: '',
+    ...overrides,
+  })
+}
+
+async function findContextCommit(): Promise<{ path: string; content: string } | null> {
+  for (let i = 0; i < 50; i++) {
+    const call = commitFileMock.mock.calls.find(c => typeof c[0] === 'string' && (c[0] as string).startsWith('contexts/'))
+    if (call) return { path: call[0] as string, content: call[1] as string }
+    await new Promise(r => setTimeout(r, 20))
+  }
+  return null
+}
+
+describe('CaptureSession attendees vs mentions', () => {
+  let container: HTMLDivElement
+  let root: ReactDOM.Root
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+      configurable: true, value: true, writable: true,
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = ReactDOM.createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(() => root.unmount())
+    container.remove()
+  })
+
+  it('does not include people_mentioned in speakers: when attendees is empty', async () => {
+    // AI says: Tara was discussed (people_mentioned) but did NOT attend (attendees empty).
+    // Previous bug: Tara would have ended up in speakers:.
+    generateMock.mockResolvedValueOnce(
+      buildClassifyResponse({ people_mentioned: ['Tara Kintner'], attendees: [] })
+    )
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <CaptureSession
+            id="t1"
+            initialContent="Free-form meeting notes. We talked about Tara's work."
+            sourceHint="meeting"
+            reports={reports}
+            onStatusChange={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </Wrapper>
+      )
+    })
+
+    const commit = await findContextCommit()
+    expect(commit).not.toBeNull()
+    // No speakers: block at all — no attendee data anywhere means the
+    // capture should fall back to people: matching (safe default), not invent
+    // a speaker list.
+    expect(commit!.content).not.toMatch(/^speakers:/m)
+    // But Tara still ends up under people: so PersonDetail can find the note.
+    expect(commit!.content).toMatch(/people:\s*\n\s+- tara/m)
+  })
+
+  it('uses ai.attendees (not people_mentioned) to build speakers:', async () => {
+    // AI: Steve attended, Tara was discussed but absent.
+    generateMock.mockResolvedValueOnce(
+      buildClassifyResponse({
+        people_mentioned: ['Tara Kintner', 'Steve Richert'],
+        attendees: ['Steve Richert'],
+      })
+    )
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <CaptureSession
+            id="t2"
+            initialContent="1:1 notes with Steve, discussed how Tara is ramping up."
+            sourceHint="meeting"
+            reports={reports}
+            onStatusChange={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </Wrapper>
+      )
+    })
+
+    const commit = await findContextCommit()
+    expect(commit).not.toBeNull()
+    // speakers includes the manager + the actual attendee Steve.
+    expect(commit!.content).toMatch(/speakers:\s*\n\s+- Mike Crittenden\s*\n\s+- Steve Richert/m)
+    // speakers does NOT include Tara (she was only mentioned).
+    expect(commit!.content).not.toMatch(/speakers:[\s\S]*Tara Kintner/m)
+    // people: still includes both names (mentioned + attended).
+    expect(commit!.content).toMatch(/people:\s*\n[\s\S]*- tara/m)
+    expect(commit!.content).toMatch(/people:\s*\n[\s\S]*- steve/m)
+  })
+
+  it('extracts deterministic speakers from cleaned transcript prefixes when AI omits them', async () => {
+    // AI is empty on both fields (worst case): we rely entirely on the
+    // **Name:** prefixes already in the cleaned transcript content.
+    generateMock.mockResolvedValueOnce(
+      buildClassifyResponse({ people_mentioned: [], attendees: [] })
+    )
+
+    const transcript = `**Mike Crittenden:** Hey, how's it going this week?
+
+**Steve Richert:** Going well, shipped the auth refactor.
+
+**Mike Crittenden:** Nice. Anything blocking?
+
+**Steve Richert:** Just the deploy infra question.`
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <CaptureSession
+            id="t3"
+            initialContent={transcript}
+            sourceHint="meeting"
+            reports={reports}
+            onStatusChange={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </Wrapper>
+      )
+    })
+
+    const commit = await findContextCommit()
+    expect(commit).not.toBeNull()
+    // Both deterministic speakers show up (current user is dedup'd against Mike Crittenden).
+    expect(commit!.content).toMatch(/speakers:\s*\n\s+- Mike Crittenden\s*\n\s+- Steve Richert/m)
+  })
+
+  it('unions deterministic transcript speakers with AI attendees, deduplicating', async () => {
+    generateMock.mockResolvedValueOnce(
+      buildClassifyResponse({
+        people_mentioned: ['Tara Kintner'],
+        // AI picks up a silent attendee that didn't have a transcript line.
+        attendees: ['Steve Richert', 'mike crittenden'],
+      })
+    )
+
+    const transcript = `**Mike Crittenden:** Welcome everyone.
+
+**Steve Richert:** Glad to be here.`
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <CaptureSession
+            id="t4"
+            initialContent={transcript}
+            sourceHint="meeting"
+            reports={reports}
+            onStatusChange={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </Wrapper>
+      )
+    })
+
+    const commit = await findContextCommit()
+    expect(commit).not.toBeNull()
+    // Dedup keeps the first-seen casing (Mike Crittenden from the current
+    // user / transcript), and Tara is never added to speakers despite being
+    // in people_mentioned.
+    expect(commit!.content).toMatch(/speakers:\s*\n\s+- Mike Crittenden\s*\n\s+- Steve Richert\s*\n---/m)
+    expect(commit!.content).not.toMatch(/speakers:[\s\S]*Tara/m)
+  })
+
+  it('skips speakers: entirely for non-meeting sources', async () => {
+    generateMock.mockResolvedValueOnce(
+      buildClassifyResponse({
+        source: 'slack',
+        people_mentioned: ['Steve Richert'],
+        attendees: ['Steve Richert'], // even if AI mistakenly fills it
+      })
+    )
+
+    await act(async () => {
+      root.render(
+        <Wrapper>
+          <CaptureSession
+            id="t5"
+            initialContent="some slack thread"
+            sourceHint="slack"
+            reports={reports}
+            onStatusChange={vi.fn()}
+            onRemove={vi.fn()}
+          />
+        </Wrapper>
+      )
+    })
+
+    const commit = await findContextCommit()
+    expect(commit).not.toBeNull()
+    expect(commit!.content).not.toMatch(/^speakers:/m)
+  })
+})

--- a/tests/renderer/transcriptCleaners.test.ts
+++ b/tests/renderer/transcriptCleaners.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { cleanTranscript, __test } from '../../src/renderer/utils/transcriptCleaners'
+import { cleanTranscript, extractSpeakersFromCleanedTranscript, __test } from '../../src/renderer/utils/transcriptCleaners'
 
 describe('cleanTranscript', () => {
   it('passes through unknown extensions unchanged', () => {
@@ -152,5 +152,85 @@ Alice: Part two.`
   it('returns the original (trimmed) text if cleaning produces nothing', () => {
     const garbage = '   not a real transcript   '
     expect(cleanTranscript('weird.vtt', garbage)).toBe('not a real transcript')
+  })
+})
+
+describe('extractSpeakersFromCleanedTranscript', () => {
+  it('returns [] for empty or speakerless content', () => {
+    expect(extractSpeakersFromCleanedTranscript('')).toEqual([])
+    expect(extractSpeakersFromCleanedTranscript('Just a paragraph of narration.')).toEqual([])
+  })
+
+  it('extracts a single **Name:** speaker prefix', () => {
+    const content = '**Mike:** Hello there.'
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike'])
+  })
+
+  it('extracts multiple speakers in cleanTranscript output form', () => {
+    const content = '**Alice:** Hi.\n\n**Bob:** Hello Alice.\n\n**Alice:** How are you?'
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Alice', 'Bob'])
+  })
+
+  it('handles full first + last names', () => {
+    const content = '**Mike Crittenden:** Kicking off.\n\n**Steve Richert:** Sounds good.'
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike Crittenden', 'Steve Richert'])
+  })
+
+  it('also recognizes the **Name**: form (colon outside bold)', () => {
+    const content = '**Alice**: Hi.\n\n**Bob**: Hello.'
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Alice', 'Bob'])
+  })
+
+  it('skips known section labels via the blocklist', () => {
+    const content = `## Summary
+
+**Summary:** This meeting covered planning.
+
+**Action items:** none
+
+**Attendees:** Mike, Steve
+
+**Mike:** Let's start.
+
+**Steve:** Sure.`
+    // The blocklist filters Summary / Action items / Attendees out, leaving real people.
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike', 'Steve'])
+  })
+
+  it('deduplicates case-insensitively, preserving first-seen casing', () => {
+    const content = '**Mike:** Hi.\n\n**mike:** Still me.\n\n**MIKE:** Yep.'
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike'])
+  })
+
+  it('only matches prefixes at the start of a line (not mid-paragraph emphasis)', () => {
+    const content = `**Mike:** Hello there.
+
+Just talking about **Tara:** she did great work this sprint.
+
+**Steve:** Agreed.`
+    // "Tara:" appears mid-paragraph, so it should be ignored.
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike', 'Steve'])
+  })
+
+  it('handles list-marker prefixes like "- **Name:**"', () => {
+    const content = `- **Mike:** First point.
+- **Steve:** Second point.`
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike', 'Steve'])
+  })
+
+  it('rejects tokens that are not plausible person names', () => {
+    const content = `**1234:** weird.
+
+**::::** more weird.
+
+**Mike:** real person.`
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike'])
+  })
+
+  it('caps name length to 4 tokens (avoids matching long bolded sentences)', () => {
+    const content = `**This Is A Very Long Sentence That Was Bolded:** not a speaker.
+
+**Mike:** real speaker.`
+    expect(extractSpeakersFromCleanedTranscript(content)).toEqual(['Mike'])
   })
 })


### PR DESCRIPTION
## Why

Captured meetings were appearing under direct reports who were only *mentioned* in the meeting, not actually present. The classify-content AI prompt asked for a single `people_mentioned` list that conflated "actual attendees" with "people we talked about", and `CaptureSession.tsx` then wrote that combined list straight into the `speakers:` frontmatter. Because `getRelevantSlugs` in `github.ts` uses `speakers:` as the authoritative attendance list, mentioned-only people ended up in the wrong report's stream. The same bug also caused `isOneOnOneWith` in `syncToReport.ts` to silently reject legitimate 1:1s whenever a third party was mentioned by name.

## Approach

**Split the AI output into two distinct fields** (`src/main/copilot.ts` + display copy in `src/shared/prompts.ts`):
- `attendees`: actual meeting participants only; empty for non-meeting sources.
- `people_mentioned`: anyone meaningfully discussed, whether or not they were present.

The old "ALWAYS include every attendee/participant of the meeting in this list, even if they only listened" sentence is gone. The new rules explicitly allow a person to appear in one, the other, or both.

**Use the cleaned transcript as ground truth.** New pure helper `extractSpeakersFromCleanedTranscript` in `transcriptCleaners.ts` pulls speakers from the `**Name:**` prefixes that `cleanTranscript` already emits for VTT/SRT inputs. It handles `**Name**:` too, anchors to line start (so mid-paragraph emphasis isn't mistaken for a speaker), filters a small blocklist of section labels (Summary, Attendees, Action items, etc.), and rejects tokens that don't look like a person name.

**Wire it together in `CaptureSession.tsx`**:

```
speakers = currentUser ∪ extractSpeakersFromCleanedTranscript(content) ∪ ai.attendees
```

`people:` is still derived from `people_mentioned` so PersonDetail can surface meetings where someone was discussed. If no attendee source yields anything (e.g. a hand-typed note with no markers and the AI returns empty), `speakers:` is omitted entirely so `getRelevantSlugs` falls back to `people:` -- the same safe default as before.

`buildMeetingAttendees` now takes an explicit attendee list (not `people_mentioned`); JSDoc explicitly warns callers not to pass mentions in.

## Trade-offs and notes

- **No migration for existing files.** Capture files committed before this fix still have over-inclusive `speakers:` lists. The user can edit them via the existing Attendees UI; we didn't write a one-time rewriter because re-deriving attendees from already-summarized content would itself rely on AI heuristics.
- **Positive side effect for sync.** This strictly tightens `speakers:`, so the 1:1 sync predicate becomes more accurate -- 1:1s that used to be silently rejected because a third party was mentioned will sync correctly when re-captured.
- **No risk of cross-report leakage being introduced.** The change can only ever produce a smaller, more accurate `speakers:` list.

## Tests

- `tests/renderer/transcriptCleaners.test.ts` -- 9 new tests for `extractSpeakersFromCleanedTranscript`: single/multiple speakers, both bold-colon forms, list markers, blocklist filtering, case-insensitive dedup, mid-paragraph false-positive rejection, non-name rejection.
- `tests/renderer/captureAttendeesIntegration.test.tsx` (new, 5 tests) -- mounts `CaptureSession` with stubbed AI responses and inspects the resulting `commitFile` payload. Covers: `people_mentioned` never leaking into `speakers:`; AI `attendees` driving `speakers:` when present; deterministic transcript extraction taking over when the AI is empty; union/dedup behavior; non-meeting sources omitting `speakers:` entirely.
- `tests/renderer/captureAttendees.test.ts` -- migrated to the new explicit-attendees contract.
- `tests/main/copilot.test.ts` -- extended `classify-content` `buildMessages` coverage to assert the new `attendees` field is documented and the over-inclusive sentence is gone.

All 150 tests across the impacted suites pass. `tsc --noEmit` is clean.